### PR TITLE
Add integration-level tests for updating.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,5 +42,5 @@ gem 'formtastic-bootstrap', '2.1.3'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '7.16.0'
+  gem 'gds-api-adapters', '7.16.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     formtastic-bootstrap (2.1.3)
       formtastic (~> 2.2)
     fssm (0.2.10)
-    gds-api-adapters (7.16.0)
+    gds-api-adapters (7.16.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -229,7 +229,7 @@ DEPENDENCIES
   factory_girl_rails (= 4.2.1)
   formtastic (= 2.2.1)
   formtastic-bootstrap (= 2.1.3)
-  gds-api-adapters (= 7.16.0)
+  gds-api-adapters (= 7.16.1)
   gds-sso (= 3.1.0)
   jquery-rails
   mocha (= 0.14.0)

--- a/test/integration/update_a_need_test.rb
+++ b/test/integration/update_a_need_test.rb
@@ -1,0 +1,58 @@
+require_relative '../integration_test_helper'
+require 'gds_api/test_helpers/need_api'
+
+class UpdateANeedTest < ActionDispatch::IntegrationTest
+  include GdsApi::TestHelpers::NeedApi
+
+  setup do
+    login_as(stub_user)
+    need_api_has_organisations(
+      "committee-on-climate-change" => "Committee on Climate Change",
+      "competition-commission" => "Competition Commission",
+      "ministry-of-justice" => "Ministry of Justice"
+    )
+    need_hash = {
+      "id" => "100001",
+      "role" => "parent",
+      "goal" => "apply for a primary school place",
+      "benefit" => "my child can start school",
+      "organisations" => []
+    }
+    need_api_has_needs([need_hash])  # For need list
+    need_api_has_need(need_hash)  # For individual need
+  end
+
+  context "Updating a need" do
+    should "be able to access edit form" do
+      visit('/needs')
+      click_on('100001')
+
+      assert page.has_field?("As a")
+      assert page.has_field?("I want to")
+      assert page.has_field?("So that")
+      # Other fields are tested in create_a_need_test.rb
+    end
+
+    should "be able to update a need" do
+      api_url = Plek.current.find('need-api') + '/needs/100001'
+      request = stub_request(:put, api_url).with(
+        :body => {
+          "role" => "grandparent",
+          "goal" => "apply for a primary school place",
+          "benefit" => "my grandchild can start school",
+          "author" => {
+            "name" => stub_user.name,
+            "email" => stub_user.email,
+            "uid" => stub_user.uid
+          }
+      }.to_json)
+      visit('/needs')
+      click_on('100001')
+      fill_in("As a", with: "grandparent")
+      fill_in("So that", with: "my grandchild can start school")
+      click_on_first("Update Need")
+
+      assert_requested request
+    end
+  end
+end


### PR DESCRIPTION
Also bump the API adapter version to fix a bug in the test helper, which uses the wrong key for the need ID field.
