### PR TITLE
Return a 404 on need view if need doesn't exist

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -18,6 +18,7 @@ class NeedsController < ApplicationController
 
   def show
     flash.keep
+    @need = load_need
     redirect_to :action => :edit, :id => params[:id]
   end
 

--- a/test/functional/needs_controller_test.rb
+++ b/test/functional/needs_controller_test.rb
@@ -190,10 +190,15 @@ class NeedsControllerTest < ActionController::TestCase
     end
 
     should "redirect to the need form" do
-      # We're not bothered whether the lookup method is invoked here
-      Need.stubs(:find)
+      Need.expects(:find).returns(stub_need)
       get :show, :id => 100001
       assert_redirected_to :action => :edit, :id => 100001
+    end
+
+    should "404 if the need doesn't exist" do
+      Need.expects(:find).with(100001).raises(Need::NotFound.new(100001))
+      get :show, :id => 100001
+      assert_response :not_found
     end
 
     should "reject non-numeric IDs" do


### PR DESCRIPTION
This incurs an extra `GET` request, but means we don't redirect to a non-existent URL. If the API adapters don't already get around the duplicate request with caching, we should be able to fix that if it's an issue.

Also, once we have separate view and edit actions, this won't be an issue any more.
