### PR TITLE
Reject POST requests with an invalid CSRF token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   rescue_from ActionController::InvalidAuthenticityToken do
-    render "public/422", layout: false, status: 422
+    render text: "Invalid authenticity token", status: 403
   end
 
   include GDS::SSO::ControllerMethods

--- a/test/functional/needs_controller_test.rb
+++ b/test/functional/needs_controller_test.rb
@@ -140,7 +140,7 @@ class NeedsControllerTest < ActionController::TestCase
     end
 
     context "CSRF protection" do
-      should "return a 422 status when not a verified request" do
+      should "return a 403 status when not a verified request" do
         # as allow_forgery_protection is disabled in the test environment, we're
         # stubbing the verified_request? method from
         # ActionController::RequestForgeryProtection::ClassMethods to return false
@@ -149,7 +149,8 @@ class NeedsControllerTest < ActionController::TestCase
 
         post :create, need: complete_need_data
 
-        assert_response 422
+        assert_response 403
+        assert_equal "Invalid authenticity token", response.body
       end
     end
 


### PR DESCRIPTION
At the moment, when the CSRF token is invalid on a non-GET request, we acknowledge it by warning in the
logs, but we continue the request. This is a Rails default.

Instead, we should explicitly reject the request to the user. Rails encourages us to override the `verify_authenticity_token` method in the controller in order to add our own behaviour.

This changes Maslow to return a HTTP 403 status, with an "Invalid authenticity token" message.
