### PR TITLE
Remove the currently_met field from Maslow

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -34,7 +34,7 @@ class Need
   ]
   NUMERIC_FIELDS = ["monthly_user_contacts", "monthly_site_views", "monthly_need_views", "monthly_searches"]
   FIELDS = ["role", "goal", "benefit", "organisation_ids", "impact", "justifications", "met_when",
-    "currently_met", "other_evidence", "legislation"] + NUMERIC_FIELDS
+    "other_evidence", "legislation"] + NUMERIC_FIELDS
   attr_accessor *FIELDS
   attr_reader :need_id, :revisions, :organisations
 
@@ -111,9 +111,6 @@ class Need
 
       hash[field] = value
     end
-
-    res["currently_met"] = (currently_met == true || currently_met == 'true') unless currently_met.nil?
-    res
   end
 
   def save

--- a/app/views/needs/_form.html.erb
+++ b/app/views/needs/_form.html.erb
@@ -27,7 +27,6 @@
   <% end %>
 
   <%= f.inputs "Provide evidence for this need", :id => "evidence" do %>
-    <%= f.input :currently_met, :label => "Do you think GOV.UK currently has functionality that meets this need?", :as => :radio %>
     <%= f.input :legislation, :label => "What legislation underpins this need?", :hint => "Please supply the law (including part and relevant section)", :as => :text, :input_html => { :class => 'long-form', :rows => 3 } %>
     <%= f.input :monthly_user_contacts, :label => "Contacts in a month in relation to this need", :hint => "Please supply the mean number of contacts per month", :input_html => { :type => :number, :min => 0 } %>
     <%= f.input :monthly_site_views, :label => "Page views for your site in a month", :hint => "Please supply the mean number of site views per month", :input_html => { :type => :number, :min => 0 } %>

--- a/test/fixtures/needs/101350.json
+++ b/test/fixtures/needs/101350.json
@@ -26,7 +26,6 @@
     "Users can book their driving test",
     "Users can find out information about the format of the test and how much it costs"
   ],
-  "currently_met": true,
   "other_evidence": "Primary service provided by the DVLA",
   "legislation": "Driving Test Act 1994, Schedule 8",
   "monthly_user_contacts": 8000,

--- a/test/fixtures/needs/101500.json
+++ b/test/fixtures/needs/101500.json
@@ -11,7 +11,6 @@
   "impact": null,
   "justifications": [],
   "met_when": [],
-  "currently_met": true,
   "other_evidence": null,
   "legislation": null,
   "monthly_user_contacts": null,

--- a/test/integration/create_a_need_test.rb
+++ b/test/integration/create_a_need_test.rb
@@ -38,7 +38,6 @@ class CreateANeedTest < ActionDispatch::IntegrationTest
 
       assert page.has_text?("Need is likely to be met when")
 
-      assert page.has_text?("Do you think GOV.UK currently has functionality that meets this need?")
       assert page.has_text?("Do you have any other qualitative or quantitative data that supports this need?")
       assert page.has_text?("Contacts in a month in relation to this need")
       assert page.has_text?("Page views for your site in a month")
@@ -58,7 +57,6 @@ class CreateANeedTest < ActionDispatch::IntegrationTest
           "justifications" => ["It's something only government does",
                                "It's straightforward advice that helps people to comply with their statutory obligations"],
           "met_when" => ["Can download a birth certificate."],
-          "currently_met" => false,
           "other_evidence" => "Free text evidence with lots more evidence",
           "legislation" => "http://www.legislation.gov.uk/stuff\nhttp://www.legislation.gov.uk/stuff",
           "monthly_user_contacts" => 10000,
@@ -82,7 +80,6 @@ class CreateANeedTest < ActionDispatch::IntegrationTest
       check("It's straightforward advice that helps people to comply with their statutory obligations")
       check("It's something only government does")
       choose("Noticed by the average member of the public")
-      choose("No")
       fill_in("Do you have any other qualitative or quantitative data that supports this need?", with: "Free text evidence with lots more evidence")
       fill_in("Contacts in a month in relation to this need", with: 10000)
       fill_in("Page views for your site in a month", with: 1000000)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,7 +53,6 @@ class ActiveSupport::TestCase
       "impact" => nil,
       "justifications" => [],
       "met_when" => [],
-      "currently_met" => nil,
       "other_evidence" => "",
       "legislation" => "",
       "monthly_user_contacts" => "",

--- a/test/unit/need_test.rb
+++ b/test/unit/need_test.rb
@@ -12,7 +12,6 @@ class NeedTest < ActiveSupport::TestCase
         "impact" => "Endangers people",
         "justifications" => ["It's something only government does", "The government is legally obliged to provide it"],
         "met_when" => ["Winning","Winning More"],
-        "currently_met" => true,
         "other_evidence" => "Ministerial priority",
         "legislation" => "Vehicle Excise and Registration Act 1994, schedule 4",
         "monthly_user_contacts" => 500,
@@ -111,23 +110,6 @@ class NeedTest < ActiveSupport::TestCase
 
           assert json.has_key?("role")
           refute json.has_key?("errors")
-        end
-
-        should "set the correct boolean value for currently_met" do
-          need = Need.new("currently_met" => true)
-          assert_equal true, need.as_json["currently_met"]
-
-          need = Need.new("currently_met" => "true")
-          assert_equal true, need.as_json["currently_met"]
-
-          need = Need.new("currently_met" => false)
-          assert_equal false, need.as_json["currently_met"]
-
-          need = Need.new("currently_met" => "false")
-          assert_equal false, need.as_json["currently_met"]
-
-          need = Need.new("currently_met" => nil)
-          assert_nil need.as_json["currently_met"]
         end
 
         should "strip leading newlines from textarea fields" do
@@ -415,7 +397,6 @@ class NeedTest < ActiveSupport::TestCase
         "impact" => nil,
         "justifications" => [],
         "met_when" => [],
-        "currently_met" => nil,
         "other_evidence" => nil,
         "legislation" => nil,
         "monthly_user_contacts" => nil,


### PR DESCRIPTION
This question on the form is redundant as it is confusing most of our users in testing, and the users which actually require this information already capture it through another process in the transition project.

This should be merged before we make the corresponding change to the Need API. Maslow can create and update needs fine without being aware of the field, as the API sets it to `null` when it's not present. 
