### PR TITLE
Refactor handling read-only fields in Need model

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -60,21 +60,29 @@ class Need
   def self.find(need_id)
     need_response = Maslow.need_api.need(need_id)
     if need_response
-      # Discard fields from the API we don't understand. Coupling the fields
-      # this app understands to the fields it expects from clients is fine, but
-      # we don't want to couple that with the fields we can use in the API.
-      accepted_fields = need_response.to_hash.with_indifferent_access.slice( *(FIELDS + READ_ONLY_FIELDS) )
-      self.new(accepted_fields, true)
+      self.new(need_response.to_hash, true)
     else
       raise NotFound, need_id
     end
   end
 
   def initialize(attrs, existing = false)
-    filtered_attributes = assign_and_filter_values(attrs)# if existing
-
     @existing = existing
-    update(filtered_attributes)
+
+    if existing
+      assign_read_only_attributes(attrs)
+
+      # discard all the read-only fields and anything else from the API which
+      # we don't understand, before calling the update method below
+      #
+      # we only do this for initializing an existing need from the API so that
+      # we can raise an error when invalid fields are submitted through the
+      # Maslow forms.
+      attrs = filtered_attributes(attrs)
+    end
+
+    # assign all the writable attributes
+    update(attrs)
   end
 
   def add_more_criteria
@@ -138,8 +146,9 @@ class Need
     else
       response_hash = Maslow.need_api.create_need(atts).to_hash
       @existing = true
-      filtered_values = assign_and_filter_values(response_hash)
-      update(filtered_values)
+
+      assign_read_only_attributes(response_hash)
+      update(filtered_attributes(response_hash))
     end
     true
   rescue GdsApi::HTTPErrorResponse => err
@@ -151,13 +160,11 @@ class Need
   end
 
 private
-  def assign_and_filter_values(original_attrs)
-    attrs = original_attrs.except("_response_info")
-
+  def assign_read_only_attributes(attrs)
     # map the read only fields from the API to instance variables of
     # the same name
     READ_ONLY_FIELDS.map(&:to_s).each do |field|
-      value = attrs.delete(field)
+      value = attrs[field]
       prepared_value = case field
                        when 'revisions'
                          prepare_revisions(value)
@@ -169,7 +176,13 @@ private
 
       instance_variable_set("@#{field}", prepared_value)
     end
-    attrs
+  end
+
+  def filtered_attributes(original_attrs)
+    # Discard fields from the API we don't understand. Coupling the fields
+    # this app understands to the fields it expects from clients is fine, but
+    # we don't want to couple that with the fields we can use in the API.
+    original_attrs.slice(*FIELDS)
   end
 
   def prepare_organisations(organisations)


### PR DESCRIPTION
Currently, read-only fields have to be defined in three places and it's cumbersome when we need to add more.

This commit refactors the Need model so that it now stores a list of read-only fields as an array. On initialize, we can iterate over this to assign the values to instance variables of the same name.

To do this, the names of the attributes need to be consistent in both the API response and the instance variables, so I've renamed the `@need_id` instance variable to `@id`, and added an alias so that both reader methods continue to work.

I've also added the new `applies_to_all_organisations` field to the list of read-only fields.
