### PR TITLE
Set i18n 'enforce locale' option

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,7 @@ module Maslow
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.i18n.enforce_available_locales = true
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"


### PR DESCRIPTION
During test runs an i18n message appears saying that the `enforce_available_locales` option will be defaulted to true. Setting it manually to true to avoid the warning
