### PR TITLE
Only send duplicate_of when closing a need

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -161,7 +161,9 @@ class Need
   end
 
   def save_as(author)
-    atts = as_json.merge("author" => author_atts(author))
+    atts = as_json
+      .reject{|k,v| k == "duplicate_of"}
+      .merge("author" => author_atts(author))
 
     if persisted?
       Maslow.need_api.update_need(@id, atts)

--- a/test/integration/create_a_need_test.rb
+++ b/test/integration/create_a_need_test.rb
@@ -65,7 +65,6 @@ class CreateANeedTest < ActionDispatch::IntegrationTest
           "yearly_need_views" => 1000,
           "yearly_searches" => 2000,
           "in_scope" => nil,
-          "duplicate_of" => nil,
           "author" => {
             "name" => stub_user.name,
             "email" => stub_user.email,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,7 +60,6 @@ class ActiveSupport::TestCase
       "yearly_need_views" => nil,
       "yearly_searches" => nil,
       "in_scope" => nil,
-      "duplicate_of" => nil
     }
   end
 end

--- a/test/unit/need_test.rb
+++ b/test/unit/need_test.rb
@@ -28,7 +28,6 @@ class NeedTest < ActiveSupport::TestCase
 
         request = @atts.merge(
           "in_scope" => nil,
-          "duplicate_of" => nil,
           "author" => {
             "name" => "O'Brien",
             "email" => "obrien@alphagov.co.uk",
@@ -488,7 +487,6 @@ class NeedTest < ActiveSupport::TestCase
         "yearly_site_views" => nil,
         "yearly_need_views" => nil,
         "yearly_searches" => nil,
-        "duplicate_of" => nil,
         "in_scope" => nil,
         "author" => {
           "name" => "O'Brien", "email" => "obrien@alphagov.co.uk", "uid" => "user-1234"


### PR DESCRIPTION
I found after https://github.com/alphagov/govuk_need_api/pull/44 that a need could no longer be updated or marked as out of scope due to the `duplicate_of` field being present in the JSON request from Maslow.

`duplicate_of` field is now only sent when closing a need as a duplicate.
