### PR TITLE
GDS::SSO::User already adds that line

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,6 @@ class User
   field "organisation_slug", type: String
 
   attr_accessible :email, :name, :uid, :version, :organisation_slug
-  attr_accessible :uid, :email, :name, :permissions, as: :oauth
 
   def self.find_by_uid(uid)
     where(uid: uid).first

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class UserTest < ActiveModel::TestCase
+
+  context "attr_accessible" do
+    should "not allow mass assignment of permissions" do
+      user = User.create!(permissions: ['signin'])
+      assert_nil user.reload.permissions
+    end
+  end
+
+end


### PR DESCRIPTION
which also won't work, because there's no
role attribute on User required to make
`attr_accessible ... as: :oauth` work.

wrote a test just to emphasize that
permissions is protected.
