### PR TITLE
Remove superfluous URL column on need page

### DIFF
--- a/app/views/needs/show.html.erb
+++ b/app/views/needs/show.html.erb
@@ -88,9 +88,6 @@
                   Title
                 </th>
                 <th scope="col">
-                  URL
-                </th>
-                <th scope="col">
                   Feedback
                 </th>
                 <th scope="col">
@@ -102,7 +99,6 @@
               <% @need.artefacts.each do |artefact| %>
                 <tr>
                   <td><%= link_to artefact.title, artefact.web_url %></td>
-                  <td><%= artefact.web_url %></td>
                   <td><% if artefact.web_url.present? %>
                         <%= link_to 'View feedback', feedback_for_page(artefact) %>
                       <% end %></td>

--- a/test/integration/view_a_need_test.rb
+++ b/test/integration/view_a_need_test.rb
@@ -190,13 +190,11 @@ class ViewANeedTest < ActionDispatch::IntegrationTest
               within "tr:first-child" do
                 assert page.has_link?("VAT rates", href: "http://www.dev.gov.uk/vat-rates")
                 assert page.has_content?("Answer")
-                assert page.has_content?("http://www.dev.gov.uk/vat-rates")
               end
 
               within "tr:nth-child(2)" do
                 assert page.has_link?("VAT", href: "http://www.dev.gov.uk/vat")
                 assert page.has_content?("Business support")
-                assert page.has_content?("http://www.dev.gov.uk/vat")
               end
             end # within tbody
           end # within table


### PR DESCRIPTION
This isn't a properly clickable link, and anyway there already is a link
to the content on GOV.UK in the adjacent column.
