### PR TITLE
Revert “This is obvious”

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -26,14 +26,20 @@ class NeedsController < ApplicationController
 
   def show
     @need = load_need
+
+    # show.html.erb
   end
 
   def actions
     @need = load_need
+
+    # actions.html.erb
   end
 
   def revisions
     @need = load_need
+
+    # revisions.html.erb
   end
 
   def edit
@@ -44,10 +50,14 @@ class NeedsController < ApplicationController
                   status: 303
       return
     end
+
+    # edit.html.erb
   end
 
   def new
     @need = Need.new({})
+
+    # new.html.erb
   end
 
   def create
@@ -99,6 +109,7 @@ class NeedsController < ApplicationController
                   status: 303
       return
     end
+    # close_as_duplicate.html.erb
   end
 
   def closed


### PR DESCRIPTION
Depending on who is on the team, how familiar they are with Rails' conventions and what else they're concentrating on at the time, what's obvious to one person will not be obvious to another. The fact that this has been added to the codebase suggests it is non-obvious enough to at least one person to be worth noting.

More generally, I would suggest being extremely careful declaring anything "obvious" or "simple". Consider the potential to upset someone who doesn't know what is obvious or simple to you.

This reverts commit 4feb4f2184d4ad5883a2048630ed15aa1c991581.
