### PR TITLE
Fix missing navbar on History page for dupe needs

### DIFF
--- a/app/views/needs/revisions.html.erb
+++ b/app/views/needs/revisions.html.erb
@@ -5,13 +5,13 @@
     <%= render partial: "needs/breadcrumb", locals: { need: @need, action: "History & Notes" } %>
   </nav>
 
+  <%= render :partial => "need_header" %>
+
   <% if @need.duplicate? %>
     <p class="need-alert">This need is a duplicate of
     <%= link_to @need.duplicate_of,
                 need_path(@need.duplicate_of) %>
     </p>
-  <% else %>
-    <%= render :partial => "need_header" %>
   <% end %>
 
   <div class="row-fluid">


### PR DESCRIPTION
Before this change, the navbar and need title disappeared
on the "History & Notes" tab for needs that were marked as dupes.

Git archeology seemed to suggest that this was originally done in order
to prevent editing of duplicate needs, but now the navbar itself contains
logic to hide the "Edit" option for duplicate needs, so this is no longer
necessary.
