### PR TITLE
Include the govuk status when listing orgs

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -3,22 +3,23 @@ require 'gds_api/need_api'
 class Organisation
   cattr_writer :organisations
 
-  attr_reader :id, :name, :abbreviation
+  attr_reader :id, :name, :abbreviation, :status
 
   def initialize(atts)
     @id = atts[:id]
     @name = atts[:name]
     @abbreviation = atts[:abbreviation]
+    @status = atts[:govuk_status]
   end
 
-  def name_with_abbreviation
+  def name_with_abbreviation_and_status
     if abbreviation.present? && abbreviation != name
       # Use square brackets around the abbreviation
       # as Chosen doesn't like matching with
       # parentheses at the start of a word
-      "#{name} [#{abbreviation}]"
+      "#{name} [#{abbreviation}] (#{status})"
     else
-      name
+      "#{name} (#{status})"
     end
   end
 

--- a/app/views/needs/_form.html.erb
+++ b/app/views/needs/_form.html.erb
@@ -12,7 +12,7 @@
       <%= f.input :organisation_ids,
                     :as => :select,
                     :collection => Organisation.all,
-                    :member_label => "name_with_abbreviation",
+                    :member_label => "name_with_abbreviation_and_status",
                     :hint => "Which government departments and agencies meet this need? You can select more than one.",
                     :label => "Departments and agencies <br/><span class='optional'>(optional)</span>".html_safe,
                     :input_html => {

--- a/app/views/needs/index.html.erb
+++ b/app/views/needs/index.html.erb
@@ -11,7 +11,7 @@
       options_from_collection_for_select(
         Organisation.all,
         "id",
-        "name_with_abbreviation",
+        "name_with_abbreviation_and_status",
         params[:organisation_id]
       ),
       prompt: "All organisations",

--- a/test/unit/organisation_test.rb
+++ b/test/unit/organisation_test.rb
@@ -38,19 +38,19 @@ class OrganisationTest < ActiveSupport::TestCase
       end
     end
 
-    should "show the organisation abbreviation" do
-      organisation = Organisation.new(id: "id", name: "name", abbreviation: "abbr")
-      assert_equal "name [abbr]", organisation.name_with_abbreviation
+    should "show the organisation abbreviation and status" do
+      organisation = Organisation.new(id: "id", name: "name", abbreviation: "abbr", govuk_status: 'live')
+      assert_equal "name [abbr] (live)", organisation.name_with_abbreviation_and_status
     end
 
     should "not show the abbreviation if it is not present" do
-      organisation = Organisation.new(id: "id", name: "name")
-      assert_equal "name", organisation.name_with_abbreviation
+      organisation = Organisation.new(id: "id", name: "name", govuk_status: 'exempt')
+      assert_equal "name (exempt)", organisation.name_with_abbreviation_and_status
     end
 
     should "not show the abbreviation if it is the same as the name" do
-      organisation = Organisation.new(id: "id", name: "name", abbreviation: "name")
-      assert_equal "name", organisation.name_with_abbreviation
+      organisation = Organisation.new(id: "id", name: "name", abbreviation: "name", govuk_status: 'joining')
+      assert_equal "name (joining)", organisation.name_with_abbreviation_and_status
     end
   end
 end


### PR DESCRIPTION
Tracker: https://www.pivotaltracker.com/story/show/66848732

This is primarily to help users avoid linking needs to closed organisations:

![screen shot 2014-04-08 at 10 54 04](https://cloud.githubusercontent.com/assets/3687/2642323/3ffea908-bf07-11e3-903e-7d32a27bb3ef.png)
