### PR TITLE
Capture enter when adding additional criteria

### DIFF
--- a/app/assets/stylesheets/needs/form.css.scss
+++ b/app/assets/stylesheets/needs/form.css.scss
@@ -30,6 +30,13 @@ form.need {
   .help-block {
     color: #aaa;
   }
+
+  /* Avoid using "display: none" so that form still submits with this input */
+  input[type="submit"].hide {
+    visibility: hidden;
+    display: inline;
+    position: absolute;
+  }
 }
 
 form.filter, form.search {

--- a/app/views/needs/_met_when.html.erb
+++ b/app/views/needs/_met_when.html.erb
@@ -1,3 +1,10 @@
+
+<%= f.action  :submit,
+              :button_html => {
+                :value => "Save",
+                :class => "btn btn-primary hide"
+              } %>
+
 <div class="string input optional stringish control-group">
   <label class="control-label" for="met-when-criteria">Need is likely to be met when the user:<br/><span class="optional">(optional)</span></label>
   <div class="controls">


### PR DESCRIPTION
Tracker: https://www.pivotaltracker.com/story/show/66409604

Hitting return when adding additional criteria results in the browser submitting the form using the first button. In this case, that is the delete button of the first criteria, which results in the first criteria being deleted because the criteria_action param is not present. This commit adds some javascript to capture carriage returns on the need criteria inputs and submit the form using the correct button.
