### PR TITLE
Remove redundant `to_hash` call in `Need.list`.

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -94,10 +94,9 @@ class Need
   def self.list(options={})
     need_response = Maslow.need_api.needs(options)
 
-    # Sadly, the `to_hash` method is only defined on the response object, not
-    # on the individual need results, so we currently have to bake this
-    # knowledge of the response format in here.
-    need_hashes = need_response.to_hash["results"]
+    # The response can be treated either as nested `OpenStruct`s or as a hash;
+    # to get the result hashes back out, we can access the key directly.
+    need_hashes = need_response["results"]
 
     need_objects = need_hashes.map { |need_hash| self.new(need_hash, true) }
     PaginatedList.new(need_objects, need_response)

--- a/test/unit/need_test.rb
+++ b/test/unit/need_test.rb
@@ -268,14 +268,15 @@ class NeedTest < ActiveSupport::TestCase
   context "listing needs" do
 
     def stub_need_response
-      stub("need response",
-        to_hash: {"results" => [{"id" => 100001}]},
+      response = stub("need response",
         pages: 2,
         total: 60,
         page_size: 50,
         current_page: 1,
         start_index: 1,
       )
+      response.stubs(:[]).with("results").returns([{"id" => 100001}])
+      response
     end
 
     should "call the need API adapter" do


### PR DESCRIPTION
As [pointed out](https://github.com/alphagov/maslow/commit/19004cf5aa9619905a3ff52744be15218a5a706e#commitcomment-5954731) by @alext.
