### PR TITLE
Reword impact of being noticed by the public

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,7 +7,7 @@ en:
       impact:
         no_impact: it would have no impact
         noticed_only_by_an_expert_audience: it would be noticed only by an expert audience
-        noticed_by_the_average_member_of_the_public: it would be noticed by the average member of the public
+        noticed_by_the_average_member_of_the_public: it would be noticed by the general public
         has_consequences_for_the_majority_of_your_users: it would have consequences for the majority of your users
         has_serious_consequences_for_your_users_and_or_their_customers: it would have serious consequences for your users and/or their customers
         endangers_people: it would endanger the lives of people

--- a/test/integration/view_a_need_test.rb
+++ b/test/integration/view_a_need_test.rb
@@ -57,7 +57,7 @@ class ViewANeedTest < ActionDispatch::IntegrationTest
         end
 
         within ".impact" do
-          assert page.has_content?("If GOV.UK didn't meet this need it would be noticed by the average member of the public")
+          assert page.has_content?("If GOV.UK didn't meet this need it would be noticed by the general public")
         end
 
         assert page.has_no_content?("This need applies to all organisations.")


### PR DESCRIPTION
Saying it is noticed by the "average member" means anyone that doesn't
notice is below average. Calling people below average isn't very polite.
