### PR TITLE
Fix SSO need-api integration in dev

### DIFF
--- a/config/initializers/api_client_credentials.rb
+++ b/config/initializers/api_client_credentials.rb
@@ -3,6 +3,6 @@
 #
 API_CLIENT_CREDENTIALS = {
   content_api: { },
-  need_api: { },
+  need_api: { bearer_token: 'xxxxx' },
   support: { }
 }


### PR DESCRIPTION
The `need-api` needs a Bearer token (any token) defined for the mock strategy
to authorise JSON requests.
