### PR TITLE
Timestamp improvements

### DIFF
--- a/app/views/needs/revisions/_revision.html.erb
+++ b/app/views/needs/revisions/_revision.html.erb
@@ -1,7 +1,7 @@
 <% revision.notes.each do |n| %>
   <li class="revision">
     <h3 class="revision-title">
-      <%= Time.parse(n.created_at).to_s(:govuk_date) %> &mdash;
+      <%= Time.zone.parse(n.created_at).to_s(:govuk_date) %> &mdash;
       Note by <%= n.author.name %>
       <% if n.author.email.present? %>
         &lt;<%= n.author.email %>&gt;
@@ -13,7 +13,7 @@
 
 <li class="revision">
   <h3 class="revision-title">
-    <%= Time.parse(revision.created_at).to_s(:govuk_date) %> &mdash;
+    <%= Time.zone.parse(revision.created_at).to_s(:govuk_date) %> &mdash;
     <%= revision.action_type.capitalize %> by
     <% if revision.author.present? -%>
       <%= revision.author.name %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module Maslow
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'London'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/test/integration/view_a_need_test.rb
+++ b/test/integration/view_a_need_test.rb
@@ -113,13 +113,13 @@ class ViewANeedTest < ActionDispatch::IntegrationTest
 
           within ".revision:nth-child(1)" do
             assert page.has_content?("Note by Donald Duck")
-            assert page.has_content?("1:00pm, 2 May 2013")
+            assert page.has_content?("2:00pm, 2 May 2013")
             assert page.has_content?("hello")
           end
 
           within ".revision:nth-child(2)" do
             assert page.has_content?("Update by Mickey Mouse <mickey.mouse@test.com>")
-            assert page.has_content?("1:00pm, 1 May 2013")
+            assert page.has_content?("2:00pm, 1 May 2013")
 
             within ".changes" do
               assert_equal 2, page.all("li").count
@@ -131,14 +131,14 @@ class ViewANeedTest < ActionDispatch::IntegrationTest
 
           within ".revision:nth-child(3)" do
             assert page.has_content?("Note by Minnie Mouse")
-            assert page.has_content?("1:00pm, 3 April 2013")
+            assert page.has_content?("2:00pm, 3 April 2013")
             assert page.has_content?("goodbye")
           end
 
           within ".revision:nth-child(4)" do
             assert page.has_content?("Update by unknown author")
             assert page.has_no_content?("<>") # catch missing email
-            assert page.has_content?("1:00pm, 1 April 2013")
+            assert page.has_content?("2:00pm, 1 April 2013")
           end
 
           within ".revision:nth-child(5)" do


### PR DESCRIPTION
- show timestamps using the [recommended style](https://www.gov.uk/design-principles/style-guide/style-points#style-dates-and-times)
- set the timezone to London
