### PR TITLE
Make view need consistent with edit/create need

### DIFF
--- a/app/views/needs/show.html.erb
+++ b/app/views/needs/show.html.erb
@@ -29,7 +29,7 @@
   <div class="need-wrapper row">
     <div class="col-md-8">
       <% if @need.met_when.any? %>
-        <h3>Need is met when</h3>
+        <h3>Need is met when the user</h3>
         <ul class="met-when">
           <% @need.met_when.each do |criterion| %>
             <li><%= criterion %></li>


### PR DESCRIPTION
When needs are input or edited we prefix the met-when field with 'need is likely to be met when the user:' but when the need is viewed we've lost 'the user' leading to the criteria becoming garbled.
