### PR TITLE
Cache Organisations for an hour

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'kaminari', '0.14.1'
 gem 'logstasher', '0.4.8'
 gem 'airbrake', '~> 4.0.0'
 gem 'cancan', '1.6.10'
+gem 'lrucache', '0.1.4'
 
 group :test do
   gem 'capybara', '2.1.0'
@@ -25,6 +26,7 @@ group :test do
   gem 'simplecov-rcov'
   gem 'mocha', '0.14.0', require: false
   gem 'webmock', '1.14.0'
+  gem 'timecop', '0.7.1'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,7 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     thor (0.19.1)
     tilt (1.4.1)
+    timecop (0.7.1)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -255,6 +256,7 @@ DEPENDENCIES
   jasmine (= 2.0.2)
   kaminari (= 0.14.1)
   logstasher (= 0.4.8)
+  lrucache (= 0.1.4)
   mocha (= 0.14.0)
   mongoid (= 3.0.23)
   plek (= 1.4.0)
@@ -263,6 +265,7 @@ DEPENDENCIES
   shoulda-context (= 1.1.5)
   simplecov (= 0.7.1)
   simplecov-rcov
+  timecop (= 0.7.1)
   uglifier (>= 1.0.3)
   unicorn
   webmock (= 1.14.0)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,13 +21,11 @@ DatabaseCleaner.clean
 class ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
 
-  setup do
-    Organisation.organisations = nil
-  end
-
   teardown do
     DatabaseCleaner.clean
     WebMock.reset!
+    Organisation.reset_cache
+    Timecop.return
   end
 
   def stub_user

--- a/test/unit/organisation_test.rb
+++ b/test/unit/organisation_test.rb
@@ -30,10 +30,19 @@ class OrganisationTest < ActiveSupport::TestCase
                    organisations.map(&:abbreviation))
     end
 
-    should "only load the organisation results once" do
+    should "cache the organisation results" do
       GdsApi::NeedApi.any_instance.expects(:organisations).once
 
       5.times do
+        Organisation.all
+      end
+    end
+
+    should "cache the organisation results, but only for an hour" do
+      GdsApi::NeedApi.any_instance.expects(:organisations).twice
+      Organisation.all
+
+      Timecop.travel(Time.now + 61.minutes) do
         Organisation.all
       end
     end


### PR DESCRIPTION
Currently, organisations are cached in each process until the app is restarted. So new and changed organisations aren't reflected in the app, possibly for months.

This change means they are only cached for an hour when fetched from govuk_need_api. govuk_need_api only updates once per day from Whitehall, but I'm going to change this in a separate pull request. Speaking with @fatbusinessman, Maslow uses govuk_need_api for organisations to avoid a dependency on Whitehall in development.

Copied from smart-answers WorldLocation model, hat tip to @alext.
