### PR TITLE
Update the need status for out-of-scope needs

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -180,6 +180,7 @@ class NeedsController < ApplicationController
 
     @need.in_scope = false
     @need.out_of_scope_reason = params["need"]["out_of_scope_reason"]
+    @need.status = { description: "out of scope", reason: params["need"]["out_of_scope_reason"] }
 
     if @need.save_as(current_user)
       flash[:need_id] = @need.need_id

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -63,7 +63,7 @@ class Need
 
   # fields which should not be updated through mass-assignment.
   # this is equivalent to using ActiveModel's attr_protected
-  PROTECTED_FIELDS = ["in_scope", "duplicate_of", "out_of_scope_reason"]
+  PROTECTED_FIELDS = ["in_scope", "duplicate_of", "out_of_scope_reason", "status"]
 
   # fields which we should create read and write accessors for
   # and which we should send back to the Need API

--- a/test/integration/create_a_need_test.rb
+++ b/test/integration/create_a_need_test.rb
@@ -69,6 +69,7 @@ class CreateANeedTest < ActionDispatch::IntegrationTest
           "in_scope" => nil,
           "duplicate_of" => nil,
           "out_of_scope_reason" => nil,
+          "status" => nil,
           "author" => {
             "name" => stub_user.name,
             "email" => stub_user.email,

--- a/test/integration/mark_as_out_of_scope_test.rb
+++ b/test/integration/mark_as_out_of_scope_test.rb
@@ -47,6 +47,10 @@ class MarkAsOutOfScopeTest < ActionDispatch::IntegrationTest
         "met_when" => ["win","awesome","more"],
         "in_scope" => false,
         "out_of_scope_reason" => "Whitespace is not acceptable",
+        "status" => {
+          "description" => "out of scope",
+          "reason" => "Whitespace is not acceptable",
+        },
         "author" => {
           "name" => stub_user.name,
           "email" => stub_user.email,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -72,7 +72,8 @@ class ActiveSupport::TestCase
       "yearly_searches" => nil,
       "in_scope" => nil,
       "duplicate_of" => nil,
-      "out_of_scope_reason" => nil
+      "out_of_scope_reason" => nil,
+      "status" => nil,
     }
   end
 end

--- a/test/unit/need_test.rb
+++ b/test/unit/need_test.rb
@@ -32,6 +32,7 @@ class NeedTest < ActiveSupport::TestCase
           "in_scope" => nil,
           "duplicate_of" => nil,
           "out_of_scope_reason" => nil,
+          "status" => nil,
           "author" => {
             "name" => "O'Brien",
             "email" => "obrien@alphagov.co.uk",
@@ -90,7 +91,7 @@ class NeedTest < ActiveSupport::TestCase
           json = Need.new(@atts).as_json
 
           # include protected fields in the list of keys to expect
-          expected_keys = (@atts.keys + ["in_scope", "duplicate_of", "out_of_scope_reason"]).sort
+          expected_keys = (@atts.keys + ["in_scope", "duplicate_of", "out_of_scope_reason", "status"]).sort
 
           assert_equal expected_keys, json.keys.sort
           assert_equal "user", json["role"]
@@ -574,6 +575,7 @@ class NeedTest < ActiveSupport::TestCase
         "duplicate_of" => nil,
         "in_scope" => nil,
         "out_of_scope_reason" => nil,
+        "status" => nil,
         "author" => {
           "name" => "O'Brien", "email" => "obrien@alphagov.co.uk", "uid" => "user-1234"
         }


### PR DESCRIPTION
This is the first step in deprecating the 'in_scope' and 'out_of_scope_reason'.

This needs to be released at the same time as https://github.com/alphagov/govuk_need_api/pull/76.
