### PR TITLE
Update 'gds-api-adapters' to latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,5 +50,5 @@ gem 'formtastic-bootstrap', '3.0.0'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '10.6.3'
+  gem 'gds-api-adapters', '16.1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,11 +80,12 @@ GEM
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
     fssm (0.2.10)
-    gds-api-adapters (10.6.3)
+    gds-api-adapters (16.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
+      rack-cache
       rest-client (~> 1.6.3)
     gds-sso (9.3.0)
       multi_json (~> 1.0)
@@ -193,8 +194,9 @@ GEM
     rake (10.3.2)
     rdoc (3.12.2)
       json (~> 1.4)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.6.8)
+      mime-types (~> 1.16)
+      rdoc (>= 2.4.2)
     safe_yaml (0.9.7)
     sass (3.2.12)
     sass-rails (3.2.6)
@@ -250,7 +252,7 @@ DEPENDENCIES
   factory_girl_rails (= 4.2.1)
   formtastic (= 2.3.0)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (= 10.6.3)
+  gds-api-adapters (= 16.1.0)
   gds-sso (= 9.3.0)
   govuk_admin_template (= 1.1.2)
   jasmine (= 2.0.3)

--- a/test/unit/note_test.rb
+++ b/test/unit/note_test.rb
@@ -28,7 +28,7 @@ class NoteTest < ActiveSupport::TestCase
 
   should "have errors set if the note couldn't be saved" do
     GdsApi::NeedApi.any_instance.expects(:create_note).raises(
-      GdsApi::HTTPErrorResponse.new(422, {"errors" => ["error"]})
+      GdsApi::HTTPErrorResponse.new(422, "invalid note", {"errors" => ["error"]})
     )
 
     note = Note.new("", "100001", @author)


### PR DESCRIPTION
Updating the adapters gem allows making changes to the test helpers.
The test has had to change because the `GdsApi::HTTPErrorResponse` class has changed.
