### PR TITLE
Remove the blue border underneath the title

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,7 +17,6 @@
 @import "chosen";
 @import "mixins";
 @import "maslow_theme";
-@import "scaffolds";
 
 // Components
 @import "needs/need";

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,3 +1,0 @@
-.block-border {
-  border-bottom: 10px solid $hm-government;
-}


### PR DESCRIPTION
... because it's not a design pattern that's used in other publishing apps.

Before:

![image](https://cloud.githubusercontent.com/assets/23801/5128715/badffc1a-70d4-11e4-83e5-5b2c11ab4a2e.png)

After:

![image](https://cloud.githubusercontent.com/assets/23801/5128707/ae008a32-70d4-11e4-904d-db11de980333.png)

/cc @fofr 
