### PR TITLE
Change the alert panels

### DIFF
--- a/app/assets/stylesheets/needs/need.css.scss
+++ b/app/assets/stylesheets/needs/need.css.scss
@@ -71,15 +71,6 @@ p.all-organisations {
   @extend .alert-info;
 }
 
-.need-alert {
-  @extend .alert;
-  @extend .alert-warning;
-
-  padding: 24px;
-  font-size: 24px;
-  line-height: 1.31579
-}
-
 .main-alert {
   @extend .alert;
   @extend .alert-warning;
@@ -87,4 +78,21 @@ p.all-organisations {
   font-size: 20px;
   padding-top: 15px;
   padding-bottom: 15px;
+}
+
+.important-note {
+  border: 1px solid $table-border-color;
+  border-left: 5px solid $state-danger-text;
+  border-radius: $border-radius-small;
+  padding: $default-vertical-padding;
+
+  .important-note-title {
+    margin-top: 0;
+    font-size: $font-size-h4;
+    color: $state-danger-text;
+  }
+
+  .important-note-body {
+    font-size: $font-size-h3;
+  }
 }

--- a/app/views/needs/_important_note.html.erb
+++ b/app/views/needs/_important_note.html.erb
@@ -1,0 +1,20 @@
+<% if @need.duplicate? || @need.out_of_scope? %>
+  <div class="important-note add-bottom-margin">
+    <div class="important-note-body">
+      <% if @need.duplicate? %>
+        <p>
+          This need is closed as a duplicate of
+          <%= link_to "#{@need.duplicate_of}: #{canonical_need_goal}",
+                      need_path(@need.duplicate_of) %>
+        </p>
+      <% end %>
+      <% if @need.out_of_scope? %>
+        <p>
+          <strong>This need is not in scope for GOV.UK</strong>
+          <br/>
+          <%= @need.status["reason"] %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/needs/_need_header.html.erb
+++ b/app/views/needs/_need_header.html.erb
@@ -1,16 +1,3 @@
-<header class="block-border add-bottom-margin">
-  <% if @need.organisations.any? %>
-    <p class="need-organisations">
-      <%= @need.organisations.map do |o| %>
-        <% link_to o.name, needs_url(organisation_id: o.id) %>
-      <% end.join(", ").html_safe %>
-    </p>
-  <% end %>
-  <div class="relative">
-    <h1 class="need-title">
-      <%= format_need_goal @need.goal %>
-    </h1>
-  </div>
-</header>
-
+<%= render partial: "title_and_orgs" %>
+<%= render partial: "important_note" %>
 <%= render partial: "nav_tabs", locals: { titles_to_links: nav_tabs_for(@need) } %>

--- a/app/views/needs/_title_and_orgs.html.erb
+++ b/app/views/needs/_title_and_orgs.html.erb
@@ -1,0 +1,14 @@
+<header class="block-border add-bottom-margin">
+  <% if @need.organisations.any? %>
+    <p class="need-organisations">
+      <%= @need.organisations.map do |o| %>
+        <% link_to o.name, needs_url(organisation_id: o.id) %>
+      <% end.join(", ").html_safe %>
+    </p>
+  <% end %>
+  <div class="relative">
+    <h1 class="need-title">
+      <%= format_need_goal @need.goal %>
+    </h1>
+  </div>
+</header>

--- a/app/views/needs/revisions.html.erb
+++ b/app/views/needs/revisions.html.erb
@@ -4,13 +4,6 @@
   <%= render partial: "needs/breadcrumb", locals: { need: @need, action: "History & Notes" } %>
   <%= render :partial => "need_header" %>
 
-  <% if @need.duplicate? %>
-    <p class="need-alert add-top-margin">This need is a duplicate of
-    <%= link_to @need.duplicate_of,
-                need_path(@need.duplicate_of) %>
-    </p>
-  <% end %>
-
   <div class="row">
     <% if current_user.can?(:create, Note) %>
       <div id="notes" class="add-top-margin col-md-6">

--- a/app/views/needs/show.html.erb
+++ b/app/views/needs/show.html.erb
@@ -12,20 +12,6 @@
     So that <%= @need.benefit %>
   </p>
 
-  <% if @need.duplicate? %>
-    <p class="need-alert">This need is closed as a duplicate of
-      <%= link_to "#{@need.duplicate_of}: #{canonical_need_goal}",
-                  need_path(@need.duplicate_of) %>
-    </p>
-  <% end %>
-  <% if @need.out_of_scope? %>
-    <div class="need-alert">
-      <strong>This need is not in scope for GOV.UK</strong>
-      <br/>
-      <%= @need.status["reason"] %>
-    </div>
-  <% end %>
-
   <div class="need-wrapper row">
     <div class="col-md-8">
       <% if @need.met_when.any? %>

--- a/test/integration/close_as_duplicate_test.rb
+++ b/test/integration/close_as_duplicate_test.rb
@@ -118,6 +118,7 @@ class CloseAsDuplicateTest < ActionDispatch::IntegrationTest
   should "not be able to edit a closed need from the history page" do
     @duplicate.merge!("duplicate_of" => "100001")
     need_api_has_need(@duplicate)
+    need_api_has_need(@need)
     visit "/needs/100002/revisions"
 
     assert page.has_no_link?("Edit")


### PR DESCRIPTION
- move the alert panels (duplicate, out of scope) to be above the tabs
- if both panels are present, combine them in one
- change the styling to match the 'important note' pattern in mainstream publisher

This uses the "important note" pattern that was first introduced in Publisher.

Before:

![image](https://cloud.githubusercontent.com/assets/23801/5129101/827a67ea-70d7-11e4-92fc-023ab9a57f2e.png)

![image](https://cloud.githubusercontent.com/assets/23801/5129156/05ded58a-70d8-11e4-920a-8623580caafc.png)

After:

![image](https://cloud.githubusercontent.com/assets/23801/5129079/661d595e-70d7-11e4-8890-b7a56bf1969d.png)

![image](https://cloud.githubusercontent.com/assets/23801/5129073/52365c4c-70d7-11e4-887f-3f03f2d61419.png)

/cc @fofr
