### PR TITLE
Display the need status on need pages

### DIFF
--- a/app/helpers/need_helper.rb
+++ b/app/helpers/need_helper.rb
@@ -99,4 +99,13 @@ module NeedHelper
   def bookmark_icon(bookmarks = [], need_id)
     bookmarks.include?(need_id.to_i) ? 'glyphicon-star' : 'glyphicon-star-empty'
   end
+
+  def status_label_class(status_description)
+    case status_description
+    when "valid" then "label-success"
+    when "not valid" then "label-danger"
+    when "valid with conditions" then "label-warning"
+    else "label-info"
+    end
+  end
 end

--- a/app/views/needs/_title_and_orgs.html.erb
+++ b/app/views/needs/_title_and_orgs.html.erb
@@ -11,4 +11,9 @@
       <%= format_need_goal @need.goal %>
     </h1>
   </div>
+  <span class="lead">
+    <span class="status label <%= status_label_class(@need.status["description"]) %>">
+      Status: <%= @need.status["description"] %>
+    </span>
+  </span>
 </header>

--- a/test/integration/view_a_need_test.rb
+++ b/test/integration/view_a_need_test.rb
@@ -36,6 +36,8 @@ class ViewANeedTest < ActionDispatch::IntegrationTest
           end
 
           assert page.has_content?("Book a driving test")
+
+          assert page.has_content?("Status: proposed")
         end
 
         within ".nav-tabs" do


### PR DESCRIPTION
This includes colours for statuses that aren't supported yet, but will be added imminently.

![image](https://cloud.githubusercontent.com/assets/23801/5164277/ae5fa0e8-73cd-11e4-86bf-7e2d8223568b.png)

![image](https://cloud.githubusercontent.com/assets/23801/5164280/bbdfc4dc-73cd-11e4-9174-f127f680b969.png)
