### PR TITLE
Allow simultaneous searching and filtering by org

### DIFF
--- a/app/views/needs/index.html.erb
+++ b/app/views/needs/index.html.erb
@@ -2,6 +2,7 @@
 <h1 class="page-title-with-border">All needs</h1>
 <div>
   <%= form_tag("/needs", method: "get", class: "form-filter-needs form-inline") do %>
+    <%= hidden_field_tag "q", params["q"] %>
     <%= label_tag "organisation_id", "Filter needs by organisation:" %>
     &nbsp;
     <%= select_tag "organisation_id",
@@ -22,6 +23,7 @@
     });
   </script>
   <%= form_tag("/needs", method: "get", class: "form-search-needs form-inline add-vertical-margins") do %>
+    <%= hidden_field_tag "organisation_id", params["organisation_id"] %>
     <%= label_tag "q", "Search needs:" %>
     &nbsp;
     <%= search_field_tag("q", params["q"], class: "search-term form-control") %>

--- a/test/need_helper.rb
+++ b/test/need_helper.rb
@@ -39,4 +39,13 @@ module NeedHelper
       }
     }.merge(options)
   end
+
+  def need_api_has_needs_for_search_and_filter(search_term, organisation, needs)
+    url = GdsApi::TestHelpers::NeedApi::NEED_API_ENDPOINT + "/needs?organisation_id=#{organisation}&q=#{search_term}"
+
+    body = response_base.merge(
+      "results" => needs
+    )
+    stub_request(:get, url).to_return(status: 200, body: body.to_json, headers: {})
+  end
 end


### PR DESCRIPTION
This has a (soft) dependency on: https://github.com/alphagov/govuk_need_api/pull/84 so should be deployed at the same time.

Ideally the page would let you change either field and then submit once, but that is a much bigger change. Giving users some way to search and filter is much better than none.
