### PR TITLE
Bump govuk_admin_template to 3.0.0 for GA fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ end
 
 gem 'chosen-rails'
 
-gem 'govuk_admin_template', '2.3.1'
+gem 'govuk_admin_template', '3.0.0'
 gem 'unicorn'
 gem 'formtastic', '2.3.0'
 gem 'formtastic-bootstrap', '3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,12 +34,12 @@ GEM
       builder
       multi_json
     arel (3.0.3)
-    autoprefixer-rails (5.2.0.1)
+    autoprefixer-rails (6.0.3)
       execjs
       json
-    bootstrap-sass (3.3.5)
+    bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
-      sass (>= 3.2.19)
+      sass (>= 3.3.0)
     builder (3.0.4)
     cancan (1.6.10)
     capybara (2.1.0)
@@ -112,7 +112,7 @@ GEM
       rails (>= 3.0.0)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
-    govuk_admin_template (2.3.1)
+    govuk_admin_template (3.0.0)
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
@@ -128,7 +128,7 @@ GEM
       rake
     jasmine-core (2.1.2)
     journey (1.0.4)
-    jquery-rails (3.1.3)
+    jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
@@ -280,7 +280,7 @@ DEPENDENCIES
   formtastic-bootstrap (= 3.0.0)
   gds-api-adapters (= 20.1.1)
   gds-sso (= 9.3.0)
-  govuk_admin_template (= 2.3.1)
+  govuk_admin_template (= 3.0.0)
   jasmine (= 2.1.0)
   kaminari (= 0.14.1)
   logstasher (= 0.4.8)


### PR DESCRIPTION
Trello: https://trello.com/c/1dS5tgTg/125-fix-analytics-in-all-16-admin-tools

Ensures the Analytics domain is set to the 
`GOVUK_APP_DOMAIN` env variable rather than 
being hardcoded.