### PR TITLE
Explicitly require test dependencies

### DIFF
--- a/test/unit/helpers/nav_tabs_helper_test.rb
+++ b/test/unit/helpers/nav_tabs_helper_test.rb
@@ -1,4 +1,5 @@
 require_relative '../../test_helper'
+require_relative '../../../app/helpers/nav_tabs_helper'
 
 class NavTabsHelperTest < ActiveSupport::TestCase
   include NavTabsHelper

--- a/test/unit/helpers/need_helper_test.rb
+++ b/test/unit/helpers/need_helper_test.rb
@@ -1,4 +1,5 @@
 require_relative '../../test_helper'
+require_relative '../../../app/helpers/need_helper'
 
 class NeedHelperTest < ActiveSupport::TestCase
   include NeedHelper


### PR DESCRIPTION
This is just generally good style, but also fixes an intermittent load
order failure in the test suite that popped up in CI when ran with
`bundle exec rake SEED=61059`

Also added this in the `nav_tabs_helper` test for consistency.

https://ci-new.alphagov.co.uk/job/govuk_maslow_branches/149/console