### PR TITLE
Fix attempted persistence of dynamic attributes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User
   field "permissions", type: Array
   field "remotely_signed_out", type: Boolean, default: false
   field "organisation_slug", type: String
+  field "organisation_content_id", type: String
   field "bookmarks", type: Array, default: Array.new
 
   delegate :can?, :cannot?, to: :ability

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -28,6 +28,10 @@ class UserTest < ActiveModel::TestCase
     end
   end
 
+  should "persist the `organisation_content_id` attribute" do
+    assert create(:user, organisation_content_id: "bleh")
+  end
+
   context "toggle bookmarks" do
     should "update the users bookmarked needs" do
       user = create(:user)


### PR DESCRIPTION
Mongoid would bork in production as a consequence of bumping
alphagov/gds-sso to `11.0.0` as it would attempt to update the given
user with the `organisation_content_id` attribute, but the `User` model
was not configured to permit dynamic attributes and no migrations to add
the requisite attributes are run from this project.

For reference, errors were of the following nature:

```
Mongoid::Errors::UnknownAttribute: Problem: Attempted to set a value for
'organisation_content_id' which is not allowed on the model User.
Summary: Without including Mongoid::Attributes::Dynamic in your model
and the attribute does not already exist in the attributes hash,
attempting to call User#organisation_content_id= for it is not allowed.
This is also triggered by passing the attribute to any method that
accepts an attributes hash, and is raised instead of getting a
NoMethodError. Resolution: You can include Mongoid::Attributes::Dynamic
if you expect to be writing values for undefined fields often.
```