### PR TITLE
Ensure SSO required attributes are present

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User
   field "organisation_slug", type: String
   field "organisation_content_id", type: String
   field "bookmarks", type: Array, default: Array.new
+  field "disabled", type: Boolean, default: false
 
   delegate :can?, :cannot?, to: :ability
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -28,8 +28,16 @@ class UserTest < ActiveModel::TestCase
     end
   end
 
-  should "persist the `organisation_content_id` attribute" do
-    assert create(:user, organisation_content_id: "bleh")
+  should "persist attributes required by GDS-SSO" do
+    assert create(
+      :user,
+      uid: "bleh",
+      name: "Mr. Smith",
+      email: "smith@example.com",
+      organisation_slug: "/something",
+      organisation_content_id: "bleh",
+      disabled: false
+    )
   end
 
   context "toggle bookmarks" do


### PR DESCRIPTION
This is in lieu of GDS-SSO's `User` module asserting on the presence of
its requisite fields upon inclusion. I'm going to make the
aforementioned change to GDS-SSO separately so for now this spec
guarantees the required attributes are present in this project's
datastore.

Also adds the missing `disabled` field declaration whose absence caused
issues upon deployment to production.