### PR TITLE
Removes deprecation warning regarding log level

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   # config.force_ssl = true
 
   # See everything in the log (default is :info)
-  # config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
In rails 5 the default value will be unified to `:debug` across all
environments. The current default is `:info`. This is now explicitly set
to preserve the current setting and remove the deprecation warning.