### PR TITLE
Get organisations from the Organisations API instead of the Need API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,5 +48,5 @@ gem 'formtastic-bootstrap', '3.1.1'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 38.1'
+  gem 'gds-api-adapters', '~> 39.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       actionpack (>= 3.2.13)
     formtastic-bootstrap (3.1.1)
       formtastic (>= 3.0)
-    gds-api-adapters (38.1.0)
+    gds-api-adapters (39.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -331,7 +331,7 @@ DEPENDENCIES
   factory_girl_rails (= 4.5.0)
   formtastic (= 3.1.3)
   formtastic-bootstrap (= 3.1.1)
-  gds-api-adapters (~> 38.1)
+  gds-api-adapters (~> 39.0)
   gds-sso (~> 11.0)
   govuk-lint
   govuk_admin_template (= 3.0.0)

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,4 +1,5 @@
 require 'gds_api/need_api'
+require 'gds_api/organisations'
 
 class Organisation
   attr_reader :id, :name, :abbreviation, :status
@@ -12,10 +13,10 @@ class Organisation
   end
 
   def initialize(atts)
-    @id = atts[:id]
-    @name = atts[:name]
-    @abbreviation = atts[:abbreviation]
-    @status = atts[:govuk_status]
+    @id = atts[:details][:slug]
+    @name = atts[:title]
+    @abbreviation = atts[:details][:abbreviation]
+    @status = atts[:details][:govuk_status]
   end
 
   def to_option
@@ -50,12 +51,12 @@ class Organisation
 
   private
   def self.load_organisations
-    (need_api.organisations || []).map {|atts|
-      self.new(atts.symbolize_keys)
+    (organisations || []).map {|atts|
+      self.new(atts.deep_symbolize_keys)
     }
   end
 
-  def self.need_api
-    Maslow.need_api
+  def self.organisations
+    GdsApi::Organisations.new(Plek.current.find('whitehall-admin')).organisations
   end
 end

--- a/app/views/needs/_form.html.erb
+++ b/app/views/needs/_form.html.erb
@@ -15,7 +15,7 @@
                     :as => :select,
                     :collection => Organisation.to_options,
                     :hint => "Which government departments and agencies meet this need? You can select more than one.",
-                    :label => "Departments and agencies <br/><span class='optional'>(optional)</span>".html_safe,
+                    :label => "Departments and agencies<br/><span class='optional'>(optional)</span>".html_safe,
                     :input_html => {
                       :multiple => true,
                       :class => "organisation-select",

--- a/test/functional/bookmarklet_controller_test.rb
+++ b/test/functional/bookmarklet_controller_test.rb
@@ -2,10 +2,11 @@ require_relative '../integration_test_helper'
 
 class BookmarkletControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::NeedApi
+  include GdsApi::TestHelpers::Organisations
 
   setup do
     login_as stub_user
-    need_api_has_organisations({})
+    organisations_api_has_organisations({})
   end
 
   context "GET bookmarklet" do

--- a/test/functional/bookmarks_controller_test.rb
+++ b/test/functional/bookmarks_controller_test.rb
@@ -2,6 +2,7 @@ require_relative '../integration_test_helper'
 
 class BookmarksControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::NeedApi
+  include GdsApi::TestHelpers::Organisations
 
   def need
     {
@@ -34,7 +35,7 @@ class BookmarksControllerTest < ActionController::TestCase
   setup do
     login_as_stub_user
     need_api_has_need_ids([need])
-    need_api_has_organisations({})
+    organisations_api_has_organisations({})
   end
 
   context "GET bookmarks" do

--- a/test/functional/needs_controller_test.rb
+++ b/test/functional/needs_controller_test.rb
@@ -1,8 +1,10 @@
 require_relative '../integration_test_helper'
 require 'gds_api/test_helpers/need_api'
+require 'gds_api/test_helpers/organisations'
 
 class NeedsControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::NeedApi
+  include GdsApi::TestHelpers::Organisations
 
   def existing_need(options = {})
     defaults = {
@@ -19,10 +21,7 @@ class NeedsControllerTest < ActionController::TestCase
 
   setup do
     login_as_stub_user
-    need_api_has_organisations(
-      "ministry-of-justice" => "Ministry of Justice",
-      "competition-commission" => "Competition Commission"
-    )
+    organisations_api_has_organisations(["ministry-of-justice", "competition-commission"])
   end
 
   context "GET index" do

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -1,8 +1,10 @@
 require_relative '../integration_test_helper'
 require 'gds_api/test_helpers/need_api'
+require 'gds_api/test_helpers/organisations'
 
 class NotesControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::NeedApi
+  include GdsApi::TestHelpers::Organisations
 
   setup do
     login_as_stub_editor

--- a/test/integration/bookmarking_needs_test.rb
+++ b/test/integration/bookmarking_needs_test.rb
@@ -1,9 +1,12 @@
 require_relative '../integration_test_helper'
 
 class BookmarkingNeedsTest < ActionDispatch::IntegrationTest
+  include GdsApi::TestHelpers::Organisations
+  include GdsApi::TestHelpers::NeedApi
+
   setup do
     login_as_stub_user
-    need_api_has_organisations([])
+    organisations_api_has_organisations([])
 
     need_1 = example_need("id" => "10001", "goal" => "apply for a primary school place")
     need_2 = example_need("id" => "10002", "goal" => "find out about becoming a British citizen")

--- a/test/integration/bookmarklet_test.rb
+++ b/test/integration/bookmarklet_test.rb
@@ -1,9 +1,11 @@
 require_relative '../integration_test_helper'
+require 'gds_api/test_helpers/organisations'
+require 'gds_api/test_helpers/need_api'
 
 class BookmarkletTest < ActionDispatch::IntegrationTest
   setup do
     login_as_stub_user
-    need_api_has_organisations([])
+    organisations_api_has_organisations([])
     need_api_has_needs([])
   end
 

--- a/test/integration/browsing_needs_test.rb
+++ b/test/integration/browsing_needs_test.rb
@@ -1,10 +1,11 @@
 # encoding: UTF-8
 require_relative '../integration_test_helper'
+require 'gds_api/test_helpers/organisations'
 
 class BrowsingNeedsTest < ActionDispatch::IntegrationTest
   setup do
     login_as_stub_user
-    need_api_has_organisations([])
+    organisations_api_has_organisations([])
   end
 
   context "viewing the list of needs" do

--- a/test/integration/close_as_duplicate_test.rb
+++ b/test/integration/close_as_duplicate_test.rb
@@ -4,7 +4,7 @@ require_relative '../integration_test_helper'
 class CloseAsDuplicateTest < ActionDispatch::IntegrationTest
   setup do
     login_as_stub_editor
-    need_api_has_organisations([])
+    organisations_api_has_organisations([])
     @need = minimal_example_need(
       "id" => "100001",
       "goal" => "apply for a primary school place",

--- a/test/integration/create_a_need_test.rb
+++ b/test/integration/create_a_need_test.rb
@@ -3,20 +3,11 @@ require_relative '../integration_test_helper'
 class CreateANeedTest < ActionDispatch::IntegrationTest
   setup do
     login_as_stub_editor
-    need_api_has_organisations(
-      "committee-on-climate-change" => {
-        "name" => "Committee on Climate Change",
-        "abbreviation" => "CCC"
-      },
-      "competition-commission" => {
-        "name" => "Competition Commission",
-        "abbreviation" => "CC"
-      },
-      "ministry-of-justice" => {
-        "name" => "Ministry of Justice",
-        "abbreviation" => "MOJ"
-      },
-    )
+    organisations_api_has_organisations([
+      "committee-on-climate-change",
+      "competition-commission",
+      "ministry-of-justice"
+    ])
     need_api_has_needs([])
   end
 
@@ -32,7 +23,7 @@ class CreateANeedTest < ActionDispatch::IntegrationTest
       assert page.has_field?("So that")
       assert page.has_text?("Departments and agencies")
       assert page.has_text?("Competition Commission")
-      assert page.has_text?("Committee on Climate Change")
+      assert page.has_text?("Committee On Climate Change")
 
       assert page.has_text?("Is this need in proposition for GOV.UK? You can tick more than one.")
       Need::JUSTIFICATIONS.each do |just|
@@ -111,7 +102,7 @@ class CreateANeedTest < ActionDispatch::IntegrationTest
       fill_in("As a", with: "User")
       fill_in("I need to", with: "find my local register office")
       fill_in("So that", with: "I can find records of birth, marriage or death")
-      select("Ministry of Justice [MOJ]", from: "Departments and agencies")
+      select("Ministry Of Justice [MOJ]", from: "Departments and agencies")
       check("It's straightforward advice that helps people to comply with their statutory obligations")
       check("It's something only government does")
       choose("Noticed by the average member of the public")

--- a/test/integration/decide_on_need_test.rb
+++ b/test/integration/decide_on_need_test.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 require_relative '../integration_test_helper'
+require 'gds_api/test_helpers/organisations'
 
 class DecideOnNeedTest < ActionDispatch::IntegrationTest
   def need_hash
@@ -18,11 +19,11 @@ class DecideOnNeedTest < ActionDispatch::IntegrationTest
 
   setup do
     login_as_stub_admin
-    need_api_has_organisations(
-      "committee-on-climate-change" => "Committee on Climate Change",
-      "competition-commission" => "Competition Commission",
-      "ministry-of-justice" => "Ministry of Justice"
-    )
+    organisations_api_has_organisations([
+      "committee-on-climate-change",
+      "competition-commission",
+      "ministry-of-justice"
+    ])
   end
 
   context "marking a need as not valid" do

--- a/test/integration/exporting_needs_test.rb
+++ b/test/integration/exporting_needs_test.rb
@@ -1,9 +1,10 @@
 require_relative '../integration_test_helper'
+require 'gds_api/test_helpers/organisations'
 
 class ExportingNeedsTest < ActionDispatch::IntegrationTest
   def filter_needs
     visit "/needs"
-    select("Department for Education [DfE]", from: "Filter needs by organisation:")
+    select("Department For Education [DFE]", from: "Filter needs by organisation:")
     click_on_first_button("Filter")
   end
 
@@ -18,11 +19,7 @@ class ExportingNeedsTest < ActionDispatch::IntegrationTest
   context "exporting a filtered list of needs" do
     context "no needs after filtering" do
       setup do
-        need_api_has_organisations(
-          "department-for-education" => { "name" => "Department for Education",
-                                          "abbreviation" => "DfE"
-                                        }
-        )
+        organisations_api_has_organisations(["department-for-education"])
         need_api_has_needs([])
         need_api_has_needs_for_organisation("department-for-education", [])
       end
@@ -39,18 +36,14 @@ class ExportingNeedsTest < ActionDispatch::IntegrationTest
 
     context "one need after filtering" do
       setup do
-        need_api_has_organisations(
-          "department-for-education" => { "name" => "Department for Education",
-                                          "abbreviation" => "DfE"
-                                        }
-        )
+        organisations_api_has_organisations(["department-for-education"])
         @needs = [
           minimal_example_need(
             "id" => "100001",
             "role" => "Foo",
             "goal" => "Bar",
             "benefit" => "Baz",
-            "organisations" => []
+            "organisations" => ["department-for-education"]
           )
         ]
         need_api_has_needs(@needs)
@@ -71,11 +64,7 @@ class ExportingNeedsTest < ActionDispatch::IntegrationTest
 
     context "several needs with met when criteria" do
       setup do
-        need_api_has_organisations(
-          "department-for-education" => { "name" => "Department for Education",
-                                          "abbreviation" => "DfE"
-                                        }
-        )
+        organisations_api_has_organisations(["department-for-education"])
         @needs = [
           minimal_example_need(
             "id" => "100001",

--- a/test/integration/filtering_needs_test.rb
+++ b/test/integration/filtering_needs_test.rb
@@ -1,4 +1,5 @@
 require_relative '../integration_test_helper'
+require 'gds_api/test_helpers/organisations'
 
 class FilteringNeedsTest < ActionDispatch::IntegrationTest
   setup do
@@ -7,13 +8,11 @@ class FilteringNeedsTest < ActionDispatch::IntegrationTest
 
   context "filtering the list of needs" do
     setup do
-      need_api_has_organisations(
-        "department-for-education" => { "name" => "Department for Education",
-                                        "abbreviation" => "DfE"
-                                      },
-        "hm-passport-office" => "HM Passport Office",
-        "home-office" => "Home Office"
-      )
+      organisations_api_has_organisations([
+        "department-for-education",
+        "hm-passport-office",
+        "home-office"
+      ])
 
       @needs = [
         minimal_example_need(
@@ -68,14 +67,14 @@ class FilteringNeedsTest < ActionDispatch::IntegrationTest
 
       assert page.has_text?("10001")
       assert page.has_text?("Apply for a primary school place")
-      assert page.has_text?("Department for Education [DfE]")
+      assert page.has_text?("Department for Education")
 
       assert page.has_text?("10003")
       assert page.has_text?("Find out about becoming a British citizen")
       assert page.has_text?("Home Office")
       assert page.has_text?("HM Passport Office")
 
-      select("Department for Education [DfE]", from: "Filter needs by organisation:")
+      select("Department For Education [DFE]", from: "Filter needs by organisation:")
       click_on_first_button("Filter")
 
       within "#needs" do
@@ -87,8 +86,7 @@ class FilteringNeedsTest < ActionDispatch::IntegrationTest
 
     should "display needs related to an organisation and filtered by text" do
       visit "/needs"
-
-      select("Department for Education [DfE]", from: "Filter needs by organisation:")
+      select("Department For Education [DFE]", from: "Filter needs by organisation:")
       click_on_first_button("Filter")
 
       within "#needs" do

--- a/test/integration/reopening_needs_test.rb
+++ b/test/integration/reopening_needs_test.rb
@@ -1,4 +1,5 @@
 require_relative '../integration_test_helper'
+require 'gds_api/test_helpers/organisations'
 
 class ReopeningNeedsTest < ActionDispatch::IntegrationTest
   def need_hash
@@ -15,7 +16,7 @@ class ReopeningNeedsTest < ActionDispatch::IntegrationTest
       "duplicate_of" => nil
     })
     login_as(stub_user)
-    need_api_has_organisations({})
+    organisations_api_has_organisations({})
     need_api_has_needs([need_hash]) # For need list
     need_api_has_need(need_hash) # For individual need
     need_api_has_need(@canonical) # For individual need

--- a/test/integration/searching_needs_test.rb
+++ b/test/integration/searching_needs_test.rb
@@ -1,8 +1,10 @@
 require_relative '../integration_test_helper'
 require 'gds_api/test_helpers/need_api'
+require 'gds_api/test_helpers/organisations'
 
 class SearchingNeedsTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::NeedApi
+  include GdsApi::TestHelpers::Organisations
 
   setup do
     login_as_stub_user
@@ -10,7 +12,7 @@ class SearchingNeedsTest < ActionDispatch::IntegrationTest
 
   context "filtering the list of needs" do
     setup do
-      need_api_has_organisations([])
+      organisations_api_has_organisations([])
 
       need_api_has_needs([
         {

--- a/test/integration/update_a_need_test.rb
+++ b/test/integration/update_a_need_test.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 require_relative '../integration_test_helper'
+require 'gds_api/test_helpers/organisations'
 
 class UpdateANeedTest < ActionDispatch::IntegrationTest
   def need_hash
@@ -21,11 +22,11 @@ class UpdateANeedTest < ActionDispatch::IntegrationTest
 
   setup do
     login_as_stub_editor
-    need_api_has_organisations(
-      "committee-on-climate-change" => "Committee on Climate Change",
-      "competition-commission" => "Competition Commission",
-      "ministry-of-justice" => "Ministry of Justice"
-    )
+    organisations_api_has_organisations([
+      "committee-on-climate-change",
+      "competition-commission",
+      "ministry-of-justice"
+    ])
   end
 
   context "updating a need" do

--- a/test/integration/view_a_need_test.rb
+++ b/test/integration/view_a_need_test.rb
@@ -1,13 +1,14 @@
 # encoding: UTF-8
 require_relative '../integration_test_helper'
+require 'gds_api/test_helpers/organisations'
 
 class ViewANeedTest < ActionDispatch::IntegrationTest
   setup do
     login_as_stub_user
-    need_api_has_organisations(
-      "driver-vehicle-licensing-agency" => "Driver and Vehicle Licensing Agency",
-      "driving-standards-agency" => "Driving Standards Agency",
-    )
+    organisations_api_has_organisations([
+      "driver-vehicle-licensing-agency",
+      "driving-standards-agency"
+    ])
   end
 
   context "given a need which exists" do
@@ -315,7 +316,7 @@ class ViewANeedTest < ActionDispatch::IntegrationTest
           "validation_conditions" => "a and b must be changed",
         })
 
-      need_api_has_organisations([])
+      organisations_api_has_organisations([])
       need_api_has_needs([need])
       need_api_has_need(need)
       content_api_has_artefacts_for_need_id("10001", [])

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -3,12 +3,14 @@ require_relative 'test_helper'
 require 'capybara/rails'
 require 'gds_api/test_helpers/content_api'
 require 'gds_api/test_helpers/need_api'
+require 'gds_api/test_helpers/organisations'
 require_relative 'need_helper'
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
   include GdsApi::TestHelpers::ContentApi
   include GdsApi::TestHelpers::NeedApi
+  include GdsApi::TestHelpers::Organisations
   include NeedHelper
 
   def login_as(user)

--- a/test/unit/organisation_test.rb
+++ b/test/unit/organisation_test.rb
@@ -1,22 +1,29 @@
 require_relative '../test_helper'
+require 'gds_api/organisations'
 
 class OrganisationTest < ActiveSupport::TestCase
   context "loading organisations" do
     setup do
       @organisation_attrs = [
-        { "id" => "committee-on-climate-change",
-          "name" => "Committee on Climate Change",
-          "abbreviation" => "CCC"
+        {
+          "title" => "Committee on Climate Change",
+          "details" => {
+            "slug" => "committee-on-climate-change",
+            "abbreviation" => "CCC"
+          },
         },
-        { "id" => "competition-commission",
-          "name" => "Competition Commission",
-          "abbreviation" => "CC"
+        {
+          "title" => "Competition Commission",
+          "details" => {
+            "slug" => "competition-commission",
+            "abbreviation" => "CC"
+          }
         }
       ]
     end
 
-    should "return organisations from the need api" do
-      GdsApi::NeedApi.any_instance.expects(:organisations)
+    should "return organisations from the organisations api" do
+      GdsApi::Organisations.any_instance.expects(:organisations)
         .returns(@organisation_attrs)
       organisations = Organisation.all
 
@@ -30,7 +37,7 @@ class OrganisationTest < ActiveSupport::TestCase
     end
 
     should "cache the organisation results" do
-      GdsApi::NeedApi.any_instance.expects(:organisations).once
+      GdsApi::Organisations.any_instance.expects(:organisations).once
 
       5.times do
         Organisation.all
@@ -38,7 +45,7 @@ class OrganisationTest < ActiveSupport::TestCase
     end
 
     should "cache the organisation results, but only for an hour" do
-      GdsApi::NeedApi.any_instance.expects(:organisations).twice
+      GdsApi::Organisations.any_instance.expects(:organisations).twice
       Organisation.all
 
       Timecop.travel(Time.zone.now + 61.minutes) do
@@ -47,17 +54,17 @@ class OrganisationTest < ActiveSupport::TestCase
     end
 
     should "show the organisation abbreviation and status" do
-      organisation = Organisation.new(id: "id", name: "name", abbreviation: "abbr", govuk_status: 'live')
+      organisation = Organisation.new(title: "name", details: { slug: "slug", abbreviation: "abbr", govuk_status: "live" })
       assert_equal "name [abbr] (live)", organisation.name_with_abbreviation_and_status
     end
 
     should "not show the abbreviation if it is not present" do
-      organisation = Organisation.new(id: "id", name: "name", govuk_status: 'exempt')
+      organisation = Organisation.new(title: "name", details: { slug: "slug", govuk_status: "exempt" })
       assert_equal "name (exempt)", organisation.name_with_abbreviation_and_status
     end
 
     should "not show the abbreviation if it is the same as the name" do
-      organisation = Organisation.new(id: "id", name: "name", abbreviation: "name", govuk_status: 'joining')
+      organisation = Organisation.new(title: "name", details: { slug: "slug", abbreviation: "name", govuk_status: "joining" })
       assert_equal "name (joining)", organisation.name_with_abbreviation_and_status
     end
   end


### PR DESCRIPTION
- The changes here are mostly changing `need_api_has_organisations` to
  be `organisations_api_has_organisations`, with the associated changing
  of parameters from hashes to arrays with only organisation_ids (slugs)
  in them.
- We had to edit some tests to use capitalized organisation names
  (Department For Education [DFE] instead of Department for Education
  [DfE]) to make them pass with this new approach, which was strange but
  we couldn't see anything obvious that was capitalising everything -
  the organisations API itself returns DfE without it all in capitals
  normally outside of tests.

This relies on https://github.com/alphagov/gds-api-adapters/pull/646, and so the tests will pass when that's merged and the gem is bumped.