### PR TITLE
Store notes in Maslow, not the Need API

### DIFF
--- a/app/assets/stylesheets/needs/revisions.scss
+++ b/app/assets/stylesheets/needs/revisions.scss
@@ -1,14 +1,14 @@
-.revisions {
+.revisions, .notes {
   margin: $default-vertical-margin 0;
   padding: 0;
 }
 
-.revision {
+.revision, .note-history {
   @extend .well;
   list-style: none;
 }
 
-.revision-title {
+.revision-title, .note-title {
   font-size: 16px;
   line-height: $default-vertical-margin;
   margin: 0 0 5px;

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -7,7 +7,15 @@ class NotesController < ApplicationController
     authorize! :create, Note
     text = params["notes"]["text"]
     need_id = params["need_id"]
-    @note = Note.new(text, need_id, current_user)
+    content_id = params["content_id"] || Maslow.need_api.content_id(need_id).body
+    author = current_user
+
+    @note = Note.new(
+      text: text,
+      need_id: need_id,
+      content_id: content_id,
+      author: author_attributes(author)
+    )
 
     if @note.save
       flash[:notice] = "Note saved"
@@ -15,5 +23,14 @@ class NotesController < ApplicationController
       flash[:error] = "Note couldn't be saved: #{@note.errors}"
     end
     redirect_to revisions_need_path(need_id)
+  end
+
+private
+  def author_attributes(author)
+    {
+      "name" => author.name,
+      "email" => author.email,
+      "uid" => author.uid
+    }
   end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -5,7 +5,7 @@ require 'json'
 class NotesController < ApplicationController
   def create
     authorize! :create, Note
-    text = params["notes"]["text"]
+    text = params["note"]["text"]
     need_id = params["need_id"]
     content_id = params["content_id"] || Maslow.need_api.content_id(need_id).body
     author = current_user
@@ -20,7 +20,7 @@ class NotesController < ApplicationController
     if @note.save
       flash[:notice] = "Note saved"
     else
-      flash[:error] = "Note couldn't be saved: #{@note.errors}"
+      flash[:error] = "Note couldn't be saved: #{@note.errors.full_messages.first}"
     end
     redirect_to revisions_need_path(need_id)
   end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,33 +1,14 @@
 class Note
-  attr_reader :text, :need_id, :author
-  attr_reader :errors
+  include Mongoid::Document
+  include Mongoid::Timestamps
 
-  def initialize(text, need_id, author)
-    @text = text
-    @need_id = need_id
-    @author = author
-  end
+  field :text, type: String
+  field :need_id, type: Integer
+  field :author, type: Hash
+  field :revision, type: String
+  field :content_id, type: String
 
-  def save
-    note_atts = {
-      "text" => text,
-      "need_id" => need_id,
-      "author" => author_atts(author)
-    }
-    Maslow.need_api.create_note(note_atts)
-    true
-  rescue GdsApi::HTTPErrorResponse => err
-    @errors = err.error_details["errors"].first
-    false
-  end
+  default_scope -> { order_by(:created_at.desc) }
 
-  private
-
-  def author_atts(author)
-    {
-      "name" => author.name,
-      "email" => author.email,
-      "uid" => author.uid
-    }
-  end
+  validates_presence_of :text, :need_id, :content_id, :author
 end

--- a/app/views/needs/revisions.html.erb
+++ b/app/views/needs/revisions.html.erb
@@ -11,7 +11,7 @@
       </div>
     <% end %>
     <div id="revision-history" class="col-md-6 accordion">
-      <%= render partial: "needs/revisions/recent_changes", locals: { need: @need } %>
+      <%= render partial: "needs/revisions/recent_changes", locals: { revisions_and_notes: @revisions_and_notes } %>
     </div>
   </div>
 

--- a/app/views/needs/revisions/_new_note_form.html.erb
+++ b/app/views/needs/revisions/_new_note_form.html.erb
@@ -1,4 +1,4 @@
-<%= semantic_form_for(:notes, url: notes_url) do |f| %>
+<%= semantic_form_for(:note, url: notes_url) do |f| %>
   <%= f.inputs do %>
     <%= hidden_field_tag :need_id, need.need_id %>
     <%= f.input :text, :label => 'Note', :as => :text, :hint => "Don't forget to save your note when you have finished.", input_html: { class: "col-md-12 add-bottom-margin" } %>

--- a/app/views/needs/revisions/_note.html.erb
+++ b/app/views/needs/revisions/_note.html.erb
@@ -1,0 +1,10 @@
+<li class="note-history">
+  <h3 class="note-title">
+    <%= note["created_at"].to_s(:govuk_date) %> &mdash;
+    Note by <%= note["author"]["name"] %>
+    <% if note["author"]["email"].present? %>
+      &lt;<%= note["author"]["email"] %>&gt;
+    <% end %>
+  </h3>
+  <%= note["text"] %>
+</li>

--- a/app/views/needs/revisions/_recent_changes.html.erb
+++ b/app/views/needs/revisions/_recent_changes.html.erb
@@ -1,4 +1,10 @@
 <h3>Recent changes</h3>
 <ul class="revisions">
-  <%= render partial: "needs/revisions/revision", collection: need.revisions %>
+  <% revisions_and_notes.each do |n| %>
+    <% if n.class.name == "Note" %>
+      <%= render partial: "needs/revisions/note", locals: { note: n } %>
+    <% elsif n.class.name == "Hash" %>
+      <%= render partial: "needs/revisions/revision", locals: { revision: n } %>
+    <% end %>
+  <% end %>
 </ul>

--- a/app/views/needs/revisions/_revision.html.erb
+++ b/app/views/needs/revisions/_revision.html.erb
@@ -1,16 +1,3 @@
-<% revision["notes"].each do |n| %>
-  <li class="revision">
-    <h3 class="revision-title">
-      <%= Time.zone.parse(n["created_at"]).to_s(:govuk_date) %> &mdash;
-      Note by <%= n["author"]["name"] %>
-      <% if n["author"]["email"].present? %>
-        &lt;<%= n["author"]["email"] %>&gt;
-      <% end %>
-    </h3>
-    <%= n["text"] %>
-  </li>
-<% end %>
-
 <li class="revision">
   <h3 class="revision-title">
     <%= Time.zone.parse(revision["created_at"]).to_s(:govuk_date) %> &mdash;

--- a/lib/tasks/clean_notes_data_from_need_api.rake
+++ b/lib/tasks/clean_notes_data_from_need_api.rake
@@ -1,0 +1,15 @@
+require 'gds_api/need_api'
+
+desc "Clean the notes imported from the Need API"
+task clean_notes_data: :environment do
+  Note.each do |n|
+    begin
+      # Change Need IDs into content_ids.
+      n.content_id = Maslow.need_api.content_id(n.need_id)
+      puts "Need ID #{n.need_id} => Content ID #{n.content_id}"
+      n.save
+    rescue GdsApi::HTTPNotFound
+      n.content_id = nil
+    end
+  end
+end

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -8,41 +8,38 @@ class NotesControllerTest < ActionController::TestCase
 
   setup do
     login_as_stub_editor
-    @note_atts = {
-      "notes" => {
-        "text" => "test"
-      },
-      "need_id" => "100001"
-    }
   end
 
   context "POST create" do
     should "be successful" do
-      stub_create_note(
-        "text" => "test",
-        "need_id" => "100001",
-        "author" => {
-          "name" => stub_user.name,
-          "email" => stub_user.email,
-          "uid" => stub_user.uid
-        }
-      )
+      @note_atts = {
+        "note" => {
+          "text" => "test"
+        },
+        "need_id" => "100001"
+      }
+      need_api_has_content_id_for_need(id: @note_atts["need_id"], content_id: SecureRandom.uuid)
 
       post :create, @note_atts
 
       assert_redirected_to revisions_need_path("100001")
-      assert_equal "Note saved", @controller.flash[:notice]
-      refute @controller.flash[:error]
+      assert_equal "Note saved", flash[:notice]
+      refute flash[:error]
     end
 
     should "return an error message if the save fails" do
-      Note.any_instance.expects(:save).returns(false)
-      Note.any_instance.expects(:errors).returns("Text can't be blank")
+      @blank_note_atts = {
+        "note" => {
+          "text" => ""
+        },
+        "need_id" => "100002"
+      }
+      need_api_has_content_id_for_need(id: @blank_note_atts["need_id"], content_id: SecureRandom.uuid)
 
-      post :create, @note_atts
+      post :create, @blank_note_atts
 
-      assert_equal "Note couldn't be saved: Text can't be blank", @controller.flash[:error]
-      refute @controller.flash[:notice]
+      assert_equal "Note couldn't be saved: Text can't be blank", flash[:error]
+      refute flash[:notice]
     end
 
     should "stop viewers from creating notes" do

--- a/test/unit/note_test.rb
+++ b/test/unit/note_test.rb
@@ -5,35 +5,31 @@ class NoteTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::NeedApi
 
   setup do
-    @author = OpenStruct.new(
+    @author = {
       name: "Winston Smith-Churchill",
       email: "winston@alphagov.co.uk",
       uid: "win5t0n"
-    )
+    }
   end
 
-  should "send note data to the need api" do
-    stub_create_note(
+  should "save note data to the database" do
+    Note.new({
       "text" => "test",
       "need_id" => "100001",
-      "author" => {
-        "name" => "Winston Smith-Churchill",
-        "email" => "winston@alphagov.co.uk",
-        "uid" => "win5t0n"
-      }
-    )
-
-    Note.new("test", "100001", @author).save
+      "content_id" => "123abc",
+      "author" => @author
+    }).save
   end
 
   should "have errors set if the note couldn't be saved" do
-    GdsApi::NeedApi.any_instance.expects(:create_note).raises(
-      GdsApi::HTTPErrorResponse.new(422, "invalid note", { "errors" => ["error"] })
-    )
-
-    note = Note.new("", "100001", @author)
+    note = Note.new({
+      "text" => "",
+      "need_id" => "100001",
+      "content_id" => "123abc",
+      "author" => @author
+    })
     note.save
 
-    assert_equal "error", note.errors
+    assert_equal "Text can't be blank", note.errors.full_messages.first
   end
 end


### PR DESCRIPTION
- This relies on a query being run in a Mongo shell to import the notes from the `need_api` database into Maslow's database, and a Rake task being run to match up its `need_id`s to `content_id`s so we can relate notes to needs in the "new" way.
- Notes are now rendered in Maslow from Maslow's database, so there have been quite a few changes to make that be able to happen in the same style as they were displayed before - notably sticking revisions and notes together again for the views, and ordering by `created_at` date to interleave the two.