### PR TITLE
Retrieve all the organisations, not just the first page

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -57,6 +57,6 @@ class Organisation
   end
 
   def self.organisations
-    GdsApi::Organisations.new(Plek.current.find('whitehall-admin')).organisations
+    GdsApi::Organisations.new(Plek.current.find('whitehall-admin')).organisations.with_subsequent_pages.to_a
   end
 end

--- a/test/unit/organisation_test.rb
+++ b/test/unit/organisation_test.rb
@@ -1,7 +1,10 @@
 require_relative '../test_helper'
 require 'gds_api/organisations'
+require 'gds_api/test_helpers/organisations'
 
 class OrganisationTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::Organisations
+
   context "loading organisations" do
     setup do
       @organisation_attrs = [
@@ -23,8 +26,8 @@ class OrganisationTest < ActiveSupport::TestCase
     end
 
     should "return organisations from the organisations api" do
-      GdsApi::Organisations.any_instance.expects(:organisations)
-        .returns(@organisation_attrs)
+      organisations_api_has_organisations_with_bodies(@organisation_attrs)
+
       organisations = Organisation.all
 
       assert_equal 2, organisations.size
@@ -37,7 +40,7 @@ class OrganisationTest < ActiveSupport::TestCase
     end
 
     should "cache the organisation results" do
-      GdsApi::Organisations.any_instance.expects(:organisations).once
+      organisations_api_has_organisations_with_bodies(@organisation_attrs)
 
       5.times do
         Organisation.all
@@ -45,7 +48,7 @@ class OrganisationTest < ActiveSupport::TestCase
     end
 
     should "cache the organisation results, but only for an hour" do
-      GdsApi::Organisations.any_instance.expects(:organisations).twice
+      organisations_api_has_organisations_with_bodies(@organisation_attrs)
       Organisation.all
 
       Timecop.travel(Time.zone.now + 61.minutes) do


### PR DESCRIPTION
- In #157, I forgot that the Organisations API paginated, and assumed the
  shorter list of organisations in my VM was a data replication quirk.
- This change gets all of the subsequent pages, and hence all of the
  organisations.