### PR TITLE
Run tests in a random order again, like normal

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,8 +25,6 @@ class ActiveSupport::TestCase
     Timecop.return
   end
 
-  ActiveSupport::TestCase.test_order = :sorted
-
   def stub_user
     @stub_user ||= create(:user)
   end


### PR DESCRIPTION
- For development purposes, when we had lots of failing tests, it was
  useful for them to be run in the same order so we could track more
  easily which ones we'd fixed. This change
  (3ad3c02ebb8e4cd4a36631ef0fc81ad1304244de) was due to be removed when
  the tests were passing, but was overlooked in the big pull request of
  All The Things.