### PR TITLE
Use the existing base_path if present

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -423,10 +423,8 @@ private
       hash[field] = value.as_json
     end
 
-    slug = @goal.parameterize
-    base_path = "/needs/#{slug}"
-
     title_suffix = need_id ? " (#{need_id})" : ""
+    update(base_path: "/needs/#{goal.parameterize}") unless base_path
 
     {
       schema_name: "need",


### PR DESCRIPTION
To generate unique base paths, the Need API added numbers to the
end. Therefore, this base path needs to be used, and you can't just
generate the base path from the goal.