### PR TITLE
Add mongoid configuration for the production environment

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -10,3 +10,8 @@ test:
       options:
         max_retries: 1
         retry_interval: 0
+
+production:
+  clients:
+    default:
+      uri: <%= ENV["MONGODB_URI"] %>


### PR DESCRIPTION
The lack of this meant that the app would not start when running in
the Rails production environment.