### PR TITLE
Revert "Remove filtering by organisation"

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -11,7 +11,9 @@ class NeedsController < ApplicationController
 
   def index
     authorize! :index, Need
-    opts = params.permit("page", "q").slice("page", "q").select { |_k, v| v.present? }.to_h
+    opts = params.permit(
+      "page", "q", "organisation_id"
+    ).slice("page", "q", "organisation_id").select { |_k, v| v.present? }.to_h
 
     @bookmarks = current_user.bookmarks
     @current_page = needs_path

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -140,6 +140,9 @@ class Need
   # 2014-03-12, they are `organisation_id`, `page` and `q`.
   def self.list(options = {})
     options = default_options.merge(options.to_h.symbolize_keys)
+    if options.key? :organisation_id
+      options[:link_organisations] = options.delete(:organisation_id)
+    end
     response = Maslow.publishing_api_v2.get_content_items(
       options.except(:load_organisation_ids)
     )

--- a/app/views/needs/_title_and_orgs.html.erb
+++ b/app/views/needs/_title_and_orgs.html.erb
@@ -1,7 +1,9 @@
 <header class="block-border add-bottom-margin">
   <% if @need.organisations.any? %>
     <p class="need-organisations">
-      <%= @need.organisations.map(&:title).join(", ") %>
+      <%= @need.organisations.map do |o| %>
+        <% link_to o.title, needs_url(organisation_id: o.content_id) %>
+      <% end.join(", ").html_safe %>
     </p>
   <% end %>
   <div class="relative">

--- a/app/views/needs/index.html.erb
+++ b/app/views/needs/index.html.erb
@@ -1,7 +1,29 @@
 <% content_for :page_title, "All needs" %>
 <h1 class="page-title-with-border">All needs</h1>
 <div>
+  <%= form_tag("/needs", method: "get", class: "form-filter-needs form-inline") do %>
+    <%= hidden_field_tag "q", params["q"] %>
+    <%= label_tag "organisation_id", "Filter needs by organisation:" %>
+    &nbsp;
+    <%= select_tag "organisation_id",
+      options_from_collection_for_select(
+        Organisation.all,
+        "content_id",
+        "title_and_publication_state",
+        params[:organisation_id]
+      ),
+      prompt: "All organisations",
+      'data-module' => 'chosen',
+      class: "organisation-select" %>
+    <%= submit_tag "Filter", name: nil, class: "btn btn-default if-js-hide" %>
+  <% end %>
+  <script>
+    $('select').change(function () {
+      $(this.form).submit();
+    });
+  </script>
   <%= form_tag("/needs", method: "get", class: "form-search-needs form-inline add-vertical-margins") do %>
+    <%= hidden_field_tag "organisation_id", params["organisation_id"] %>
     <%= label_tag "q", "Search needs:" %>
     &nbsp;
     <%= search_field_tag("q", params["q"], class: "search-term form-control") %>

--- a/test/integration/filtering_needs_test.rb
+++ b/test/integration/filtering_needs_test.rb
@@ -12,8 +12,60 @@ class FilteringNeedsTest < ActionDispatch::IntegrationTest
       [
         "apply for a primary school place",
         "apply for a secondary school place",
-        "find out about becoming a British citizen primary"
+        "find out about becoming a British citizen"
       ].zip(@needs).each { |goal, x| x["details"]["goal"] = goal }
+
+      @needs.each { |need| publishing_api_has_item(need) }
+
+      publishing_api_has_linked_items(
+        [
+          {
+            title: "Linked item title",
+            base_path: "linked_foo",
+            document_type: "guide"
+          }
+        ],
+        content_id: @needs[0]["content_id"],
+        link_type: "meets_user_needs",
+        fields: ["title", "base_path", "document_type"]
+      )
+
+      @department_of_education = SecureRandom.uuid
+      @home_office = SecureRandom.uuid
+      @hm_passport_office = SecureRandom.uuid
+      publishing_api_has_linkables(
+        [
+          {
+            content_id: @department_of_education,
+            title: "Department for Education",
+          },
+          {
+            content_id: @home_office,
+            title: "Home Office",
+          },
+          {
+            content_id: @hm_passport_office,
+            title: "HM Passport Office",
+          },
+        ], document_type: "organisation"
+      )
+
+      publishing_api_has_links(
+        content_id: @needs[0]["content_id"],
+        links: {
+          organisations: [@department_of_education],
+        }
+      )
+      publishing_api_has_links(
+        content_id: @needs[1]["content_id"],
+        links: {
+          organisations: [@department_of_education],
+        }
+      )
+      publishing_api_has_links(
+        content_id: @needs[2]["content_id"],
+        links: {}
+      )
 
       publishing_api_has_content(
         @needs,
@@ -21,10 +73,8 @@ class FilteringNeedsTest < ActionDispatch::IntegrationTest
           per_page: 50
         )
       )
-      publishing_api_has_linkables([], document_type: "organisation")
-      @needs.each do |need|
-        publishing_api_has_links(content_id: need["content_id"], links: {})
-      end
+
+      needs_linked_to_education = @needs[0..1]
 
       publishing_api_has_content(
         @needs.select { |x| x["details"]["goal"].include? "primary" },
@@ -33,15 +83,54 @@ class FilteringNeedsTest < ActionDispatch::IntegrationTest
           q: "primary"
         )
       )
+
+      publishing_api_has_content(
+        needs_linked_to_education,
+        Need.default_options.merge(
+          per_page: 50,
+          link_organisations: @department_of_education
+        )
+      )
+
+      publishing_api_has_content(
+        needs_linked_to_education.select { |x| x["details"]["goal"].include? "primary" },
+        Need.default_options.merge(
+          per_page: 50,
+          q: "primary",
+          link_organisations: @department_of_education
+        )
+      )
+    end
+
+    should "display needs related to an organisation" do
+      visit "/needs"
+
+      assert page.has_text?("Apply for a primary school place")
+      assert page.has_text?("Department for Education")
+
+      assert page.has_text?("Find out about becoming a British citizen")
+      assert page.has_text?("Home Office")
+      assert page.has_text?("HM Passport Office")
+
+      select("Department for Education", from: "Filter needs by organisation:")
+      click_on_first_button("Filter")
+
+      within "#needs" do
+        assert page.has_text?("Department for Education")
+        assert page.has_text?("Apply for a primary school place")
+        assert page.has_no_text?("Find out about becoming a British citizen")
+      end
     end
 
     should "display needs related to an organisation and filtered by text" do
       visit "/needs"
+      select("Department for Education", from: "Filter needs by organisation:")
+      click_on_first_button("Filter")
 
       within "#needs" do
         assert page.has_text?("Apply for a primary school place")
         assert page.has_text?("Apply for a secondary school place")
-        refute page.has_text?("find out about becoming a British citizen primary")
+        refute page.has_text?("find out about becoming a British citizen")
       end
 
       fill_in("Search needs", with: "primary")
@@ -50,7 +139,29 @@ class FilteringNeedsTest < ActionDispatch::IntegrationTest
       within "#needs" do
         assert page.has_text?("Apply for a primary school place")
         refute page.has_text?("Apply for a secondary school place")
-        refute page.has_text?("find out about becoming a British citizen primary")
+        refute page.has_text?("find out about becoming a British citizen")
+      end
+    end
+
+    context "filtering from showing a need" do
+      should "filter when clicking on an organisation while showing a need" do
+        visit "/needs"
+        click_on "Apply for a primary school place"
+
+        within ".need-organisations" do
+          assert page.has_link?(
+                   "Department for Education",
+                   href: needs_url(organisation_id: @department_of_education)
+                 )
+        end
+
+        click_on "Department for Education"
+
+        within "#needs" do
+          assert page.has_text?("Department for Education")
+          assert page.has_text?("Apply for a primary school place")
+          assert page.has_no_link?("Department for Education")
+        end
       end
     end
   end


### PR DESCRIPTION
And restore the functionality. This functionality was removed because
at the time it was believed not to be feasible to do with the
Publishing API without adding functionality there.

However, it turns out this was possible all along. This commit reverts
the removal of the functionality, as well as the removal of the
related tests, and adjusts the tests so that they still work and
pass.

This reverts commit 1293ae392f103df24b4ad3c34d6b0330dec9ac15 among
other things.

![maslow-needs-with-organisation-filter](https://user-images.githubusercontent.com/1130010/28027662-c8b7275a-6591-11e7-8a70-2762b2b93126.png)
![maslow-need-with-organisation-link](https://user-images.githubusercontent.com/1130010/28027663-c8b766e8-6591-11e7-9dc8-2df515a4d44d.png)
