### PR TITLE
Send update_type with put_content

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,4 +369,4 @@ DEPENDENCIES
   webmock (= 1.22.1)
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -123,6 +123,7 @@ class Need
       "met_when" => [],
       "justifications" => [],
       "organisation_ids" => [],
+      "update_type" => "major",
     }
 
     update(
@@ -433,7 +434,8 @@ private
       ],
       document_type: "need",
       title: "As a #{@role}, I need to #{@goal}, so that #{@benefit}#{title_suffix}",
-      details: details
+      details: details,
+      update_type: update_type,
     }
   end
 

--- a/test/integration/create_a_need_test.rb
+++ b/test/integration/create_a_need_test.rb
@@ -68,6 +68,7 @@ class CreateANeedTest < ActionDispatch::IntegrationTest
             type: "exact"
           }
         ],
+        update_type: "major",
         document_type: "need",
         title: "As a User, I need to find my local register office, so that I can find records of birth, marriage or death",
         details: {


### PR DESCRIPTION
It will shortly be required by the Publishing API.

[Trello Card](https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)