### PR TITLE
Handle external URLs

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
   </li>
 <% end %>
 <% content_for :navbar_right do %>
-  Hello, <%= link_to current_user.name, Plek.current.find('signon') %>
+  Hello, <%= link_to current_user.name, Plek.new.external_url_for('signon') %>
   &bull; <%= link_to 'Sign out', gds_sign_out_path %>
 <% end %>
 <% content_for :footer_version do %><%= CURRENT_RELEASE_SHA %><% end %>

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -2,5 +2,5 @@ GDS::SSO.config do |config|
   config.user_model   = 'User'
   config.oauth_id     = ENV['OAUTH_ID'] || "abcdefg"
   config.oauth_secret = ENV['OAUTH_SECRET'] || "secret"
-  config.oauth_root_url = Plek.find('signon')
+  config.oauth_root_url = Plek.new.external_url_for('signon')
 end


### PR DESCRIPTION
Use the new external_url_for method of Plek to generate external URLs
for Signon. This makes Maslow more compatible with environments where
there is a difference between internal and external routing, which is
the way GOV.UK is being deployed to Amazon Web Services.