### PR TITLE
Remove deprecated signin step

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,6 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
 
   before_action :authenticate_user!
-  before_action :require_signin_permission!
 
   private
   def verify_authenticity_token


### PR DESCRIPTION
Remove `require_signin_permission!` which was deprecated in gds-sso
13.3.0: https://github.com/alphagov/gds-sso/blob/master/CHANGELOG.md#1330

The controllers already call `authenticate_user!`, which ensures that users can only view pages if they are authenticated with Signon.