### PR TITLE
Remove all left over references to the Need API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The bootstrap script should get you up and running in the development environmen
 
 ### GDS development
 
-If you're using the development VM, you should run the app from the `development` repository using Bowler and Foreman. The Need API will automatically be started alongside Maslow.
+If you're using the development VM, you should run the app from the
+`development` repository using Bowler and Foreman.
 
     cd development/
     bowl maslow

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -135,10 +135,7 @@ class Need
     @persisted = false
   end
 
-  # Retrieve a list of needs from the Need API
-  #
-  # The parameters are the same as passed through to the Need API: as of
-  # 2014-03-12, they are `organisation_id`, `page` and `q`.
+  # Retrieve a list of needs from the Publishing API
   def self.list(options = {})
     options = default_options.merge(options.to_h.symbolize_keys)
     if options.key? :organisation_id
@@ -465,7 +462,7 @@ private
 
   def strip_newline_from_textareas(attrs)
     # Rails prepends a newline character into the textarea fields in the form.
-    # Strip these so that we don't send them to the Need API.
+    # Strip these so that we don't send them to the Publishing API.
     %i(legislation other_evidence).each do |field|
       attrs[field].sub!(/\A\n/, "") if attrs[field].present?
     end

--- a/test/integration/create_a_need_test.rb
+++ b/test/integration/create_a_need_test.rb
@@ -200,7 +200,7 @@ class CreateANeedTest < ActionDispatch::IntegrationTest
       end
     end
 
-    should "handle 422 errors from the Need API" do
+    should "handle 422 errors from the Publishing API" do
       put_url = %r{\A#{Plek.find('publishing-api')}/v2/content/}
       stub_request(:put, put_url).to_return(status: 422)
 


### PR DESCRIPTION
The Need API was the service that used to store needs, but they were
migrated to the Publishing API a while back.