### PR TITLE
Add Dalli to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 5.2.3'
 
+gem 'dalli', '~> 2.7'
 gem 'govspeak', '~> 6'
 gem 'mongoid', '~> 6'
 gem 'plek', '~> 2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    dalli (2.7.10)
     database_cleaner (1.7.0)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
@@ -373,6 +374,7 @@ DEPENDENCIES
   cancancan (~> 3)
   capybara (~> 3)
   chosen-rails
+  dalli (~> 2.7)
   database_cleaner (~> 1)
   factory_bot_rails (~> 5)
   formtastic (~> 3)


### PR DESCRIPTION
This is currently preventing deploys, following on from #398.

```
09:10:41  ** [out :: backend-2.backend.staging.publishing.service.gov.uk] E, [2019-04-25T09:10:41.703181 #22197] ERROR -- sentry: ** [Raven] Failed to submit event: RuntimeError: Could not find cache store adapter for mem_cache_store (cannot load such file -- dalli)
```