### PR TITLE
README: Remove old, dev VM 'how to run the app' instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,11 @@ part of the GOV.UK Publishing Platform.
 - The Ruby Gems listed in the Gemfile
 - A running instance of the [Publishing API](https://github.com/alphagov/publishing-api)
 
-## Getting started
-
-The bootstrap script should get you up and running in the development environment. It runs Bundler and creates a stub user in the database.
-
-    ./script/bootstrap
-    bundle exec unicorn -p 3001
-
-### GDS development
-
-If you're using the development VM, you should run the app from the
-`development` repository using Bowler and Foreman.
-
-    cd development/
-    bowl maslow
-
-From your host machine, you should be able to access the app at <http://maslow.dev.gov.uk/>.
-
 ## User accounts
 
-Authentication is provided by the [GDS-SSO](https://github.com/alphagov/gds-sso) gem, and in the production environment an instance of [Signon](https://github.com/alphagov/signonotron2) must be running in order to sign in.
+Authentication is provided by the [GDS-SSO](https://github.com/alphagov/gds-sso) gem, and in the production environment an instance of [Signon](https://github.com/alphagov/signon) must be running in order to sign in.
 
-In the development environment, the mock strategy is used by default. This removes the requirement for authentication, instead returning the first user in the database as the current user. For this to work, a user must exist - there's a user defined in `db/seeds.rb` which will be created with the bootstrap script.
+In the development environment, the mock strategy is used by default. This removes the requirement for authentication, instead returning the first user in the database as the current user. For this to work, a user must exist - there's a user defined in `db/seeds.rb`.
 
 ## Licence
 


### PR DESCRIPTION
- These instructions referenced the deprecated GOV.UK Development VM, `bowler`, \*and\* `./startup.sh`.
- The new standard is [GOV.UK Docker](https://github.com/alphagov/govuk-docker).