### PR TITLE
Make entire repository pass Rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
 
-task default: [:test, 'jasmine:ci']
+task default: [:test, "jasmine:ci"]

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -1,4 +1,4 @@
-if File.exist?("#{Rails.root}/REVISION")
+if File.exist?(Rails.root.join("REVISION"))
   revision = `cat #{Rails.root}/REVISION`.chomp
   CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA
 else

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,6 +2,6 @@
 
 unless User.where(permissions: "signin").exists?
   @user = User.new(name: "Winston Smith-Churchill", email: "winston@alphagov.co.uk")
-  @user.permissions = ["signin"]
+  @user.permissions = %w[signin]
   @user.save!
 end


### PR DESCRIPTION
This is depended on by https://github.com/alphagov/govuk-jenkinslib/pull/66.