### PR TITLE
Use GovukTest to configure Jasmine Selenium

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,8 @@ group :test do
 end
 
 group :development, :test do
+  gem "govuk_test"
   gem "jasmine"
-  gem "jasmine_selenium_runner", require: false
+  gem "jasmine_selenium_runner"
   gem "rubocop-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
+    brakeman (4.10.0)
     bson (4.10.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -152,6 +153,12 @@ GEM
       rails (>= 5.0.0.1)
       rouge
       sprockets (< 4)
+    govuk_test (2.0.0)
+      brakeman (~> 4.6)
+      capybara
+      puma
+      selenium-webdriver (>= 3.142)
+      webdrivers (>= 4)
     hashdiff (1.0.1)
     hashie (4.1.0)
     htmlentities (4.3.4)
@@ -254,6 +261,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.5)
+    puma (5.0.2)
+      nio4r (~> 2.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -411,6 +420,7 @@ DEPENDENCIES
   govspeak
   govuk_admin_template
   govuk_app_config
+  govuk_test
   jasmine
   jasmine_selenium_runner
   kaminari

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,12 +1,7 @@
-require "jasmine/runners/selenium"
-require "webdrivers/chromedriver"
+require "jasmine_selenium_runner/configure_jasmine"
 
-Jasmine.configure do |config|
-  config.prevent_phantom_js_auto_install = true
-  config.runner = lambda { |formatter, jasmine_server_url|
-    options = Selenium::WebDriver::Chrome::Options.new
-    options.headless!
-    webdriver = Selenium::WebDriver.for(:chrome, options: options)
-    Jasmine::Runners::Selenium.new(formatter, jasmine_server_url, webdriver, 50)
-  }
+class HeadlessChromeJasmineConfigurer < JasmineSeleniumRunner::ConfigureJasmine
+  def selenium_options
+    { options: GovukTest.headless_chrome_selenium_options }
+  end
 end

--- a/spec/javascripts/support/jasmine_selenium_runner.yml
+++ b/spec/javascripts/support/jasmine_selenium_runner.yml
@@ -1,0 +1,2 @@
+browser: chrome
+configuration_class: HeadlessChromeJasmineConfigurer

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,10 +11,8 @@ require "mocha/minitest"
 require "webmock/test_unit"
 require "gds_api/test_helpers/publishing_api"
 
-WebMock.disable_net_connect!(
-  allow_localhost: true,
-  allow: ["chromedriver.storage.googleapis.com"],
-)
+GovukTest.configure
+WebMock.disable_net_connect!(allow_localhost: true)
 
 DatabaseCleaner.strategy = :truncation
 DatabaseCleaner.clean


### PR DESCRIPTION
Trello: https://trello.com/c/PlDX9ps8/180-run-govuk-docker-containers-as-root-to-allow-application-specific-mounts

This applies the govuk_test gem to this project and then uses that as a
means to share configuration with Jasmine. This allows this repo to be
compatible with the upcoming change to govuk-docker [1].

[1]: https://github.com/alphagov/govuk-docker/pull/394