### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,10 +4,6 @@ library("govuk")
 
 node("mongodb-2.4") {
   govuk.buildProject(
-    beforeTest: {
-      sh("yarn install")
-    },
     brakeman: true,
-    sassLint: false,
   )
 }


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80
And the Yarn install step is unnecessary as of https://github.com/alphagov/govuk-jenkinslib/pull/82