### PR TITLE
Remove specifying of default branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,5 @@
 library("govuk@default-branch")
 
 node("mongodb-2.4") {
-  govuk.buildProject(defaultBranch: "main")
+  govuk.buildProject()
 }


### PR DESCRIPTION
This option is no longer necessary thanks to https://github.com/alphagov/govuk-jenkinslib/pull/85