### PR TITLE
Remove version reference to `default-branch`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library("govuk@default-branch")
+library("govuk")
 
 node("mongodb-2.4") {
   govuk.buildProject()


### PR DESCRIPTION
https://github.com/alphagov/govuk-jenkinslib/pull/84 has been merged in now, so we don't need to reference this branch.