### PR TITLE
Run CI against Mongo 3.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,6 @@
 
 library("govuk")
 
-node("mongodb-2.4") {
+node("mongodb-3.2") {
   govuk.buildProject()
 }


### PR DESCRIPTION
Maslow runs against DocumentDB which is a version of Mongo 3.6. We don't
have a MongoDB version of 3.6 available in CI so this runs against 3.2,
which is what we do have available. A version of MongoDB 3 is required for https://github.com/alphagov/maslow/pull/779

I've created a card for Publishing backlog to add MongoDB 3.6 to CI: https://trello.com/c/xscwvHAm/578-ci-doesnt-have-mongodb-36-available-so-our-apps-have-to-test-against-older-versions

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
