### PR TITLE
Revert  "Bump mail from 2.7.1 to 2.8.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "govspeak"
 gem "govuk_admin_template"
 gem "govuk_app_config"
 gem "kaminari"
-gem "mail", "~> 2.8.0" # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
+gem "mail", "~> 2.7.1" # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mongoid"
 gem "plek"
 gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,11 +218,8 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -462,7 +459,7 @@ DEPENDENCIES
   govuk_app_config
   govuk_test
   kaminari
-  mail (~> 2.8.0)
+  mail (~> 2.7.1)
   mocha
   mongoid
   plek


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
