### PR TITLE
Add GitHub Action workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "Jenkinsfile"
+      - ".git**"
+  pull_request:
+
+jobs:
+  security-analysis:
+    name: Security Analysis
+    uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
+
+  lint-scss:
+    name: Lint SCSS
+    uses: alphagov/govuk-infrastructure/.github/workflows/stylelint.yml@main
+    with:
+      files: "app/assets/stylesheets/"
+
+  lint-javascript:
+    name: Lint JavaScript
+    uses: alphagov/govuk-infrastructure/.github/workflows/standardx.yml@main
+    with:
+      files: "'app/assets/javascripts/**/*.js' 'spec/javascripts/**/*.js'"
+
+  lint-ruby:
+    name: Lint Ruby
+    uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
+
+  test-javascript:
+    name: Test JavaScript
+    uses: alphagov/govuk-infrastructure/.github/workflows/jasmine.yml@main
+    with:
+      useWithRails: true
+
+  test-ruby:
+    name: Test Ruby
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup MongoDB
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-mongodb@main
+        with:
+          version: 3.6
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup Node
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
+
+      - name: Precompile assets
+        uses: alphagov/govuk-infrastructure/.github/actions/precompile-rails-assets@main
+
+      - name: Initialize database
+        env:
+          RAILS_ENV: test
+        run: bundle exec rails db:setup
+
+      - name: Run Minitest
+        env:
+          RAILS_ENV: test
+        run: bundle exec rake test
+


### PR DESCRIPTION
This is an initial workflow to enable CI using GitHub Actions. It makes use of
reusable workflows and composite actions defined in govuk-infrastructure. The
CI workflow is initially only used to support deployments to the new EKS
infrastructure and not to immediately replace the CI workflow in Jenkins.

The CI workflow makes use of individual jobs to run each testing and linting
tool. This allows the processes to run concurrently and improves the visibility
of status in the GitHub UI.

Most jobs make use of reusable workflows as they are consistent across the
majority of our repositories - this allows us to easily maintain them in a
single place. However, the test-ruby job (and/or integration-tests) is defined
per repo as backing services and other dependencies vary greatly between repos.
Backing services (such as databases) are created using a composite action
instead of a job service. This is because they contain a lot of shared config
and makes it easier for us to maintain.
