### PR TITLE
Include the app name in the Rails asset path.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,8 @@ module Maslow
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
 
-    config.assets.prefix = ENV.fetch("ASSETS_PREFIX", "/assets")
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/maslow"
   end
 end

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -1,5 +1,5 @@
 {
-  "srcDir": "public/assets",
+  "srcDir": "public/assets/maslow",
   "srcFiles": [
     "govuk-admin-template-*.js",
     "application-*.js"


### PR DESCRIPTION
See alphagov/manuals-publisher#2004.
