### PR TITLE
Prefix memcache keys with the app name.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  config.cache_store = :mem_cache_store
+  config.cache_store = :mem_cache_store, nil, { namespace: :maslow, compress: true } unless ENV["HEROKU_APP_NAME"]
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
This helps prevent clashes when sharing a memcache with other applications, which will be the case after Replatforming.

Maslow is the only GOV.UK app that was using ActiveSupport::MemCacheStore without a namespace.