### PR TITLE
Fix release version in footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
   Hello, <%= link_to current_user.name, Plek.external_url_for('signon') %>
   &bull; <%= link_to 'Sign out', gds_sign_out_path %>
 <% end %>
-<% content_for :footer_version do %><%= CURRENT_RELEASE_SHA %><% end %>
+<% content_for :footer_version, ENV.fetch("SENTRY_RELEASE", "null")[0..18] %>
 <% content_for :app_title do %>GOV.UK Maslow<% end %>
 <% content_for :content do %>
 <% [:notice, :alert, :error].select { |k|  flash[k].present? }.each do |k| %>

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -1,6 +1,0 @@
-if File.exist?(Rails.root.join("REVISION"))
-  revision = `cat #{Rails.root}/REVISION`.chomp
-  CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA
-else
-  CURRENT_RELEASE_SHA = "development".freeze
-end


### PR DESCRIPTION
This has been broken since we moved to EKS and the SHA is no longer provided.

We can use the [SENTRY_RELEASE](https://github.com/alphagov/govuk-helm-charts/blob/077117e7f40c096a958f9e0b853a2bd76cf43f26/charts/generic-govuk-app/templates/deployment.yaml#L92C1-L92C1) environment variable which is defined for every app and takes its value from the container image's tag.

If for whatever reason the image tag is not defined it will display `null`, which should make it clearer (instead of displaying `development`) that this data is not being pulled in successfully.

Before:
<img width="1185" alt="Screenshot 2023-09-25 at 18 05 25" src="https://github.com/alphagov/maslow/assets/19667619/31189bee-370d-4cfb-87fb-0115c7267791">

After (tested in Integration):
<img width="1191" alt="Screenshot 2023-09-25 at 18 04 32" src="https://github.com/alphagov/maslow/assets/19667619/0cc4d39e-67f1-45de-ab28-b2f54dbc6bd8">

Trello card: https://trello.com/c/uoKDUcbV/3182-fix-broken-version-footer-in-publishing-apps-2

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
