### PR TITLE
Migrate to Dart Sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@
 
 # Ignore compiled assets
 /public/assets
+/app/assets/builds/*
+!/app/assets/builds/.keep
 
 .yarn/*
 !.yarn/patches

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "bootsnap", require: false
 gem "cancancan"
 gem "chosen-rails"
 gem "dalli"
+gem "dartsass-rails"
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "govspeak"
@@ -15,7 +16,6 @@ gem "govuk_publishing_components"
 gem "kaminari"
 gem "mongoid"
 gem "plek"
-gem "sassc-rails"
 gem "uglifier"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,9 @@ GEM
       rexml
     crass (1.0.6)
     dalli (3.2.6)
+    dartsass-rails (0.5.0)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     database_cleaner-core (2.0.1)
     database_cleaner-mongoid (2.0.1)
       database_cleaner-core (~> 2.0.0)
@@ -622,6 +625,15 @@ GEM
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    sass-embedded (1.70.0)
+      google-protobuf (~> 3.25)
+      rake (>= 13.0.0)
+    sass-embedded (1.70.0-aarch64-linux-gnu)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.70.0-arm64-darwin)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.70.0-x86_64-linux-gnu)
+      google-protobuf (~> 3.25)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -696,6 +708,7 @@ DEPENDENCIES
   capybara
   chosen-rails
   dalli
+  dartsass-rails
   database_cleaner-mongoid
   factory_bot_rails
   gds-api-adapters
@@ -713,7 +726,6 @@ DEPENDENCIES
   rails (= 7.1.3)
   rails-controller-testing
   rubocop-govuk
-  sassc-rails
   shoulda-context
   simplecov
   uglifier

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,3 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
-//= link_directory ../stylesheets .css
+//= link_tree ../builds

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,10 +31,6 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # Rather than use a CSS compressor, use the SASS style to perform compression.
-  config.sass.style = :compressed
-  config.sass.line_comments = false
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,0 +1,1 @@
+Rails.application.config.dartsass.build_options << " --quiet-deps"

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,0 +1,1 @@
+Rake::Task["assets:precompile"].enhance(["dartsass:build"])


### PR DESCRIPTION
## Description 

LibSass has been deprecated. We're moving to Dart Sass. This follows the upgrade guide found here
https://docs.publishing.service.gov.uk/manual/migrate-to-dart-sass-from-libsass.html

## Trello card

https://trello.com/c/qeNHFPZN/1667-migrate-to-dart-sass

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
