### PR TITLE
Mount /component-guide

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
     GovukHealthcheck::Mongoid,
   )
 
+  mount GovukPublishingComponents::Engine, at: "/component-guide"
+
   resources :bookmarks, only: [:index], param: :content_id do
     collection do
       post :toggle


### PR DESCRIPTION
This should be enabled on every app which pulls in govuk_publishing_components.

Trello: https://trello.com/c/ITcz5b1G/3417-enable-component-guide-on-non-dev-environments

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
